### PR TITLE
Context

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,6 +56,9 @@ RSpec/ExampleLength:
 RSpec/FilePath:
   Enabled: false
 
+RSpec/IndexedLet:
+  Enabled: false
+
 RSpec/MessageChain:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,9 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Enabled: false
 
+Metrics/ParameterLists:
+  Enabled: false
+
 Naming/PredicateName:
   Enabled: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- TODO: describe new version -->
+
 ## v2.0.0
 
 ### Breaking:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- TODO: describe context feature -->
+
 # Rabarber: Simplified Authorization for Rails
 
 [![Gem Version](https://badge.fury.io/rb/rabarber.svg)](http://badge.fury.io/rb/rabarber)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <!-- TODO: describe context feature -->
+<!-- TODO: explain that virtually every method is able to receive context -->
 
 # Rabarber: Simplified Authorization for Rails
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ end
 ```
 This grants access to `index` action for users with `accountant` or `admin` role, and access to `destroy` action for `admin` users only.
 
-Please note that Rabarber does not provide any built-in data scoping mechanism as it is not a part of the authorization layer and is not necessarily role specific or has anything to do with the current user. The business logic can vary drastically depending on the application, so you're encouraged to limit the data visibility yourself, for example, in the same way as in the example above, where `accountant` role can only see paid invoices.
+_Note: Rabarber does not provide any built-in data scoping mechanism as it is not a part of the authorization layer and is not necessarily role specific or has anything to do with the current user. The business logic can vary drastically depending on the application, so you're encouraged to limit the data visibility yourself, for example, in the same way as in the example above, where `accountant` role can only see paid invoices._
 
 You can also define controller-wide rules (without `action` argument):
 
@@ -294,9 +294,7 @@ end
 
 This allows everyone to access `OrdersController` and its children and also `index` action in `InvoicesController`. This extends to scenarios where there is no user present, i.e. when the method responsible for returning the currently authenticated user in your application returns `nil`.
 
-If the user is not authenticated (the method responsible for returning the currently authenticated user in your application returns `nil`), Rabarber will handle this situation as if the user has no roles.
-
-If you've set `must_have_roles` setting to `true`, then only the users with at least one role can gain access. This setting can be useful if your requirements are such that users without roles (or unauthenticated users) are not allowed to access anything.
+_Note: If the user is not authenticated (the method responsible for returning the currently authenticated user in your application returns `nil`), Rabarber will handle this situation as if the user has no roles. If you've set `must_have_roles` setting to `true`, then only the users with at least one role can gain access. This setting can be useful if your requirements are such that users without roles are not allowed to access anything._
 
 Also keep in mind that rules defined in child classes don't override parent rules but rather add to them:
 ```rb

--- a/lib/generators/rabarber/roles_generator.rb
+++ b/lib/generators/rabarber/roles_generator.rb
@@ -2,7 +2,8 @@
 
 require "rails/generators/migration"
 
-# TODO: is seamless migration to the new table structure possible?
+# TODO: seamless migration to the new table structure seems to be impossible, because of the unique index on name
+# TODO: do something to help users migrate their data
 
 module Rabarber
   class RolesGenerator < Rails::Generators::Base

--- a/lib/generators/rabarber/roles_generator.rb
+++ b/lib/generators/rabarber/roles_generator.rb
@@ -2,6 +2,8 @@
 
 require "rails/generators/migration"
 
+# TODO: is seamless migration to the new table structure possible?
+
 module Rabarber
   class RolesGenerator < Rails::Generators::Base
     include Rails::Generators::Migration

--- a/lib/generators/rabarber/templates/create_rabarber_roles.rb.erb
+++ b/lib/generators/rabarber/templates/create_rabarber_roles.rb.erb
@@ -3,10 +3,12 @@
 class CreateRabarberRoles < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version.to_s %>]
   def change
     create_table :rabarber_roles<%= ", id: :uuid" if options[:uuid] %> do |t|
-      t.string :name, null: false, index: { unique: true }
+      t.string :name, null: false
       t.belongs_to :context, polymorphic: true, index: true<%= ", type: :uuid" if options[:uuid] %>
       t.timestamps
     end
+
+    add_index :rabarber_roles, [:name, :context_type, :context_id], unique: true
 
     create_table :rabarber_roles_roleables, id: false do |t|
       t.belongs_to :role, null: false, index: true, foreign_key: { to_table: :rabarber_roles }<%= ", type: :uuid" if options[:uuid] %>

--- a/lib/generators/rabarber/templates/create_rabarber_roles.rb.erb
+++ b/lib/generators/rabarber/templates/create_rabarber_roles.rb.erb
@@ -4,6 +4,7 @@ class CreateRabarberRoles < ActiveRecord::Migration[<%= ActiveRecord::Migration.
   def change
     create_table :rabarber_roles<%= ", id: :uuid" if options[:uuid] %> do |t|
       t.string :name, null: false, index: { unique: true }
+      t.belongs_to :context, polymorphic: true, index: true<%= ", type: :uuid" if options[:uuid] %>
       t.timestamps
     end
 

--- a/lib/rabarber.rb
+++ b/lib/rabarber.rb
@@ -8,6 +8,7 @@ require "active_support"
 
 require_relative "rabarber/input/base"
 require_relative "rabarber/input/action"
+require_relative "rabarber/input/context"
 require_relative "rabarber/input/dynamic_rule"
 require_relative "rabarber/input/role"
 require_relative "rabarber/input/roles"

--- a/lib/rabarber.rb
+++ b/lib/rabarber.rb
@@ -30,6 +30,7 @@ require_relative "rabarber/helpers/helpers"
 require_relative "rabarber/models/concerns/has_roles"
 require_relative "rabarber/models/role"
 
+require_relative "rabarber/core/context"
 require_relative "rabarber/core/permissions"
 require_relative "rabarber/core/permissions_integrity_checker"
 

--- a/lib/rabarber/audit/events/base.rb
+++ b/lib/rabarber/audit/events/base.rb
@@ -46,6 +46,8 @@ module Rabarber
         end
 
         def roleable_identity(with_roles:)
+          # TODO: roles with context
+          # TODO: it seems the log messages will be changed significantly because of the context, worth mentioning in changelog
           if roleable
             model_name = roleable.model_name.human
             primary_key = roleable.class.primary_key

--- a/lib/rabarber/audit/events/base.rb
+++ b/lib/rabarber/audit/events/base.rb
@@ -34,28 +34,16 @@ module Rabarber
         end
 
         def message
+          # TODO: it seems the log messages will be changed significantly because of the context, worth mentioning in changelog
           raise NotImplementedError
         end
 
         def identity
-          roleable_identity(with_roles: identity_with_roles?)
-        end
-
-        def identity_with_roles?
-          raise NotImplementedError
-        end
-
-        def roleable_identity(with_roles:)
-          # TODO: roles with context
-          # TODO: it seems the log messages will be changed significantly because of the context, worth mentioning in changelog
           if roleable
             model_name = roleable.model_name.human
-            primary_key = roleable.class.primary_key
-            roleable_id = roleable.public_send(primary_key)
+            roleable_id = roleable.public_send(roleable.class.primary_key)
 
-            roles = with_roles ? ", roles: #{roleable.roles}" : ""
-
-            "#{model_name} with #{primary_key}: '#{roleable_id}'#{roles}"
+            "#{model_name}##{roleable_id}"
           else
             "Unauthenticated #{Rabarber::HasRoles.roleable_class.model_name.human.downcase}"
           end

--- a/lib/rabarber/audit/events/roles_assigned.rb
+++ b/lib/rabarber/audit/events/roles_assigned.rb
@@ -15,6 +15,7 @@ module Rabarber
         end
 
         def message
+          # TODO: roles with context
           "[Role Assignment] #{identity} has been assigned the following roles: #{roles_to_assign}, current roles: #{current_roles}"
         end
 

--- a/lib/rabarber/audit/events/roles_assigned.rb
+++ b/lib/rabarber/audit/events/roles_assigned.rb
@@ -15,12 +15,11 @@ module Rabarber
         end
 
         def message
-          # TODO: roles with context
-          "[Role Assignment] #{identity} has been assigned the following roles: #{roles_to_assign}, current roles: #{current_roles}"
+          "[Role Assignment] #{identity} | context: '#{context}', assigned roles: #{roles_to_assign}, current roles: #{current_roles}"
         end
 
-        def identity_with_roles?
-          false
+        def context
+          specifics.fetch(:context).to_s
         end
 
         def roles_to_assign

--- a/lib/rabarber/audit/events/roles_revoked.rb
+++ b/lib/rabarber/audit/events/roles_revoked.rb
@@ -15,6 +15,7 @@ module Rabarber
         end
 
         def message
+          # TODO: roles with context
           "[Role Revocation] #{identity} has been revoked from the following roles: #{roles_to_revoke}, current roles: #{current_roles}"
         end
 

--- a/lib/rabarber/audit/events/roles_revoked.rb
+++ b/lib/rabarber/audit/events/roles_revoked.rb
@@ -15,12 +15,11 @@ module Rabarber
         end
 
         def message
-          # TODO: roles with context
-          "[Role Revocation] #{identity} has been revoked from the following roles: #{roles_to_revoke}, current roles: #{current_roles}"
+          "[Role Revocation] #{identity} | context: '#{context}', revoked roles: #{roles_to_revoke}, current roles: #{current_roles}"
         end
 
-        def identity_with_roles?
-          false
+        def context
+          specifics.fetch(:context).to_s
         end
 
         def roles_to_revoke

--- a/lib/rabarber/audit/events/unauthorized_attempt.rb
+++ b/lib/rabarber/audit/events/unauthorized_attempt.rb
@@ -15,11 +15,19 @@ module Rabarber
         end
 
         def message
-          "[Unauthorized Attempt] #{identity} attempted to access '#{path}'"
+          "[Unauthorized Attempt] #{identity}#{roles}path: '#{path}'".tr('"', "'")
         end
 
-        def identity_with_roles?
-          true
+        def roles
+          if roleable
+            roles_list = roleable.rabarber_roles.group_by { |role| role.context.to_s }.transform_values { |roles|
+              roles.pluck(:name).map(&:to_sym)
+            }.sort.to_h
+
+            " | roles: #{roles_list}, "
+          else
+            " | "
+          end
         end
 
         def path

--- a/lib/rabarber/audit/events/unauthorized_attempt.rb
+++ b/lib/rabarber/audit/events/unauthorized_attempt.rb
@@ -15,19 +15,7 @@ module Rabarber
         end
 
         def message
-          "[Unauthorized Attempt] #{identity}#{roles}path: '#{path}'".tr('"', "'")
-        end
-
-        def roles
-          if roleable
-            roles_list = roleable.rabarber_roles.group_by { |role| role.context.to_s }.transform_values { |roles|
-              roles.pluck(:name).map(&:to_sym)
-            }.sort.to_h
-
-            " | roles: #{roles_list}, "
-          else
-            " | "
-          end
+          "[Unauthorized Attempt] #{identity} | path: '#{path}'"
         end
 
         def path

--- a/lib/rabarber/controllers/concerns/authorization.rb
+++ b/lib/rabarber/controllers/concerns/authorization.rb
@@ -12,6 +12,14 @@ module Rabarber
 
     class_methods do
       def grant_access(action: nil, roles: nil, if: nil, unless: nil)
+        # TODO: this must accept context argument which is nil by default, but can also be a class or an instance
+        # TODO: the context stored in memory must be represented as a hash { class_name: ..., id: ... }
+        # TODO: both values in the hash can be nil
+        # TODO: when access permissions are checked, the roles must be checked for the context
+        # TODO: class_name.nil? && id.nil? means checking for global roles
+        # TODO: class_name.nil? && !id.nil? means checking for class roles (e.g. a user can be an admin of every Project)
+        # TODO: !class_name.nil? && !id.nil? means checking for instance roles
+        # TODO: default nil context should provide a seamless upgrade as previous versions supported only global roles
         dynamic_rule, negated_dynamic_rule = binding.local_variable_get(:if), binding.local_variable_get(:unless)
 
         Rabarber::Core::Permissions.add(

--- a/lib/rabarber/controllers/concerns/authorization.rb
+++ b/lib/rabarber/controllers/concerns/authorization.rb
@@ -11,7 +11,7 @@ module Rabarber
     end
 
     class_methods do
-      def grant_access(action: nil, roles: nil, if: nil, unless: nil)
+      def grant_access(action: nil, roles: nil, context: nil, if: nil, unless: nil)
         # TODO: this must accept context argument which is nil by default, but can also be a class or an instance
         # TODO: the context stored in memory must be represented as a hash { class_name: ..., id: ... }
         # TODO: both values in the hash can be nil
@@ -26,6 +26,7 @@ module Rabarber
           self,
           Rabarber::Input::Action.new(action).process,
           Rabarber::Input::Roles.new(roles).process,
+          Rabarber::Core::Context.new(context),
           Rabarber::Input::DynamicRule.new(dynamic_rule).process,
           Rabarber::Input::DynamicRule.new(negated_dynamic_rule).process
         )

--- a/lib/rabarber/core/cache.rb
+++ b/lib/rabarber/core/cache.rb
@@ -11,8 +11,11 @@ module Rabarber
       private_constant :CACHE_PREFIX
 
       def fetch(roleable_id, context:, &block)
-        default_options = { expires_in: 1.hour, race_condition_ttl: 5.seconds }
-        enabled? ? Rails.cache.fetch(key_for(roleable_id, context), **default_options, &block) : yield
+        if enabled?
+          Rails.cache.fetch(key_for(roleable_id, context), expires_in: 1.hour, race_condition_ttl: 5.seconds, &block)
+        else
+          yield
+        end
       end
 
       def delete(*roleable_ids, context:)

--- a/lib/rabarber/core/cache.rb
+++ b/lib/rabarber/core/cache.rb
@@ -29,7 +29,7 @@ module Rabarber
       end
 
       def key_for(id, context)
-        "#{CACHE_PREFIX}:#{Digest::SHA256.hexdigest("#{id}#{context}")}"
+        "#{CACHE_PREFIX}:#{Digest::SHA256.hexdigest("#{id}#{context.to_s}")}" # rubocop:disable Lint/RedundantStringCoercion
       end
     end
   end

--- a/lib/rabarber/core/context.rb
+++ b/lib/rabarber/core/context.rb
@@ -5,8 +5,8 @@ module Rabarber
     class Context
       attr_reader :context
 
-      def initialize(context, wrap: false)
-        @context = wrap ? context : Rabarber::Input::Context.new(context).process
+      def initialize(context)
+        @context = context.is_a?(Hash) ? context : Rabarber::Input::Context.new(context).process
       end
 
       def to_h

--- a/lib/rabarber/core/context.rb
+++ b/lib/rabarber/core/context.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Rabarber
+  module Core
+    class Context
+      attr_reader :context
+
+      def initialize(context)
+        @context = Rabarber::Input::Context.new(context).process
+      end
+
+      def to_h
+        context
+      end
+
+      def to_s
+        case context
+        in { context_type: nil, context_id: nil } then "Global"
+        in { context_type: context_type, context_id: nil } then context_type
+        in { context_type: context_type, context_id: context_id } then "#{context_type}##{context_id}"
+        else raise "Unexpected context: #{context}"
+        end
+      end
+    end
+  end
+end

--- a/lib/rabarber/core/context.rb
+++ b/lib/rabarber/core/context.rb
@@ -6,7 +6,7 @@ module Rabarber
       attr_reader :context
 
       def initialize(context)
-        @context = context.is_a?(Hash) ? context : Rabarber::Input::Context.new(context).process
+        @context = Rabarber::Input::Context.new(context).process
       end
 
       def to_h

--- a/lib/rabarber/core/context.rb
+++ b/lib/rabarber/core/context.rb
@@ -5,8 +5,8 @@ module Rabarber
     class Context
       attr_reader :context
 
-      def initialize(context)
-        @context = Rabarber::Input::Context.new(context).process
+      def initialize(context, wrap: false)
+        @context = wrap ? context : Rabarber::Input::Context.new(context).process
       end
 
       def to_h

--- a/lib/rabarber/core/context.rb
+++ b/lib/rabarber/core/context.rb
@@ -13,6 +13,7 @@ module Rabarber
         context
       end
 
+      # TODO: perhaps this class is not needed and to_s can be moved to audit base class
       def to_s
         case context
         in { context_type: nil, context_id: nil } then "Global"

--- a/lib/rabarber/core/permissions.rb
+++ b/lib/rabarber/core/permissions.rb
@@ -19,8 +19,8 @@ module Rabarber
       end
 
       class << self
-        def add(controller, action, roles, dynamic_rule, negated_dynamic_rule)
-          rule = Rabarber::Core::Rule.new(action, roles, dynamic_rule, negated_dynamic_rule)
+        def add(controller, action, roles, context, dynamic_rule, negated_dynamic_rule)
+          rule = Rabarber::Core::Rule.new(action, roles, context, dynamic_rule, negated_dynamic_rule)
 
           if action
             instance.storage[:action_rules][controller] += [rule]

--- a/lib/rabarber/core/roleable.rb
+++ b/lib/rabarber/core/roleable.rb
@@ -4,6 +4,7 @@ module Rabarber
   module Core
     module Roleable
       def roleable
+        # TODO: how about NullRoleable
         send(Rabarber::Configuration.instance.current_user_method)
       end
 

--- a/lib/rabarber/core/roleable.rb
+++ b/lib/rabarber/core/roleable.rb
@@ -8,7 +8,8 @@ module Rabarber
       end
 
       def roleable_roles
-        roleable&.roles.to_a
+        # TODO: this will work, but the roles are no longer cached
+        roleable ? roleable.rabarber_roles : Rabarber::Role.none
       end
     end
   end

--- a/lib/rabarber/core/rule.rb
+++ b/lib/rabarber/core/rule.rb
@@ -3,11 +3,12 @@
 module Rabarber
   module Core
     class Rule
-      attr_reader :action, :roles, :dynamic_rule, :negated_dynamic_rule
+      attr_reader :action, :roles, :context, :dynamic_rule, :negated_dynamic_rule
 
-      def initialize(action, roles, dynamic_rule, negated_dynamic_rule)
+      def initialize(action, roles, context, dynamic_rule, negated_dynamic_rule)
         @action = action
         @roles = Array(roles)
+        @context = context
         @dynamic_rule = dynamic_rule
         @negated_dynamic_rule = negated_dynamic_rule
       end

--- a/lib/rabarber/core/rule.rb
+++ b/lib/rabarber/core/rule.rb
@@ -18,9 +18,11 @@ module Rabarber
       end
 
       def roles_permitted?(roleable_roles)
-        return false if Rabarber::Configuration.instance.must_have_roles && roleable_roles.empty?
+        contextual_roles = roleable_roles.where(context.to_h).names
 
-        roles.empty? || roles.intersection(roleable_roles).any?
+        return false if Rabarber::Configuration.instance.must_have_roles && contextual_roles.empty?
+
+        roles.empty? || roles.intersection(contextual_roles).any?
       end
 
       def dynamic_rule_followed?(dynamic_rule_receiver)

--- a/lib/rabarber/helpers/helpers.rb
+++ b/lib/rabarber/helpers/helpers.rb
@@ -4,6 +4,8 @@ module Rabarber
   module Helpers
     include Rabarber::Core::Roleable
 
+    # TODO: add context, also roleable_roles is now ActiveRecord::Relation
+
     def visible_to(*roles, &block)
       return unless roleable_roles.intersection(Rabarber::Input::Roles.new(roles).process).any?
 

--- a/lib/rabarber/input/action.rb
+++ b/lib/rabarber/input/action.rb
@@ -11,10 +11,8 @@ module Rabarber
 
       def processed_value
         case value
-        when String, Symbol
-          value.to_sym
-        when nil
-          value
+        when String, Symbol then value.to_sym
+        when nil then value
         end
       end
 

--- a/lib/rabarber/input/context.rb
+++ b/lib/rabarber/input/context.rb
@@ -12,8 +12,8 @@ module Rabarber
       def processed_value
         case value
         when nil then { context_type: nil, context_id: nil }
-        when Class then { context_type: value, context_id: nil }
-        when ActiveRecord::Base then { context_type: value.class, context_id: value.public_send(value.class.primary_key) }
+        when Class then { context_type: value.to_s, context_id: nil }
+        when ActiveRecord::Base then { context_type: value.class.to_s, context_id: value.public_send(value.class.primary_key) }
         end
       end
 

--- a/lib/rabarber/input/context.rb
+++ b/lib/rabarber/input/context.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Rabarber
+  module Input
+    class Context < Rabarber::Input::Base
+      def valid?
+        value.nil? || value.is_a?(Class) || value.is_a?(ActiveRecord::Base)
+      end
+
+      private
+
+      def processed_value
+        case value
+        when nil then { context_type: nil, context_id: nil }
+        when Class then { context_type: value, context_id: nil }
+        when ActiveRecord::Base then { context_type: value.class, context_id: value.public_send(value.class.primary_key) }
+        end
+      end
+
+      def default_error_message
+        "Context must be a Class or an instance of ActiveRecord::Base"
+      end
+    end
+  end
+end

--- a/lib/rabarber/input/dynamic_rule.rb
+++ b/lib/rabarber/input/dynamic_rule.rb
@@ -11,10 +11,8 @@ module Rabarber
 
       def processed_value
         case value
-        when String, Symbol
-          value.to_sym
-        when Proc, nil
-          value
+        when String, Symbol then value.to_sym
+        when Proc, nil then value
         end
       end
 

--- a/lib/rabarber/models/concerns/has_roles.rb
+++ b/lib/rabarber/models/concerns/has_roles.rb
@@ -9,6 +9,7 @@ module Rabarber
 
       @@included = name
 
+      # TODO: it looks like rabarber_roles relation has to be cached, not the role names
       has_and_belongs_to_many :rabarber_roles, class_name: "Rabarber::Role",
                                                foreign_key: "roleable_id",
                                                join_table: "rabarber_roles_roleables"

--- a/lib/rabarber/models/concerns/has_roles.rb
+++ b/lib/rabarber/models/concerns/has_roles.rb
@@ -14,52 +14,59 @@ module Rabarber
                                                join_table: "rabarber_roles_roleables"
     end
 
-    def roles
-      # TODO: real context
-      Rabarber::Core::Cache.fetch(roleable_id, context: nil) { rabarber_roles.names }
+    def roles(context: nil)
+      processed_context = process_context(context)
+      Rabarber::Core::Cache.fetch(roleable_id, context: processed_context) do
+        rabarber_roles.where(processed_context.to_h).names
+      end
     end
 
-    def has_role?(*role_names)
-      roles.intersection(process_role_names(role_names)).any?
+    def has_role?(*role_names, context: nil)
+      roles(context: context).intersection(process_role_names(role_names)).any?
     end
 
     def assign_roles(*role_names, context: nil, create_new: true)
-      # TODO: real context
       processed_role_names = process_role_names(role_names)
-      processed_context = Rabarber::Core::Context.new(context)
+      processed_context = process_context(context)
 
-      create_new_roles(processed_role_names) if create_new
+      create_new_roles(processed_role_names, processed_context) if create_new
 
-      roles_to_assign = Rabarber::Role.where(name: processed_role_names - rabarber_roles.names)
+      roles_to_assign = Rabarber::Role.where(
+        name: (processed_role_names - rabarber_roles.where(processed_context.to_h).names),
+        **processed_context.to_h
+      )
 
       if roles_to_assign.any?
-        delete_roleable_cache
+        delete_roleable_cache(processed_context)
         rabarber_roles << roles_to_assign
 
         Rabarber::Audit::Events::RolesAssigned.trigger(
-          self, context: processed_context, roles_to_assign: roles_to_assign.names, current_roles: roles
+          self, context: processed_context, roles_to_assign: roles_to_assign.names, current_roles: roles(context: context)
         )
       end
 
-      roles
+      roles(context: context)
     end
 
     def revoke_roles(*role_names, context: nil)
-      # TODO: real context
       processed_role_names = process_role_names(role_names)
-      processed_context = Rabarber::Core::Context.new(context)
-      roles_to_revoke = Rabarber::Role.where(name: processed_role_names.intersection(roles))
+      processed_context = process_context(context)
+
+      roles_to_revoke = Rabarber::Role.where(
+        name: processed_role_names.intersection(roles(context: context)),
+        **processed_context.to_h
+      )
 
       if roles_to_revoke.any?
-        delete_roleable_cache
+        delete_roleable_cache(processed_context)
         self.rabarber_roles -= roles_to_revoke
 
         Rabarber::Audit::Events::RolesRevoked.trigger(
-          self, context: processed_context, roles_to_revoke: roles_to_revoke.names, current_roles: roles
+          self, context: processed_context, roles_to_revoke: roles_to_revoke.names, current_roles: roles(context: context)
         )
       end
 
-      roles
+      roles(context: context)
     end
 
     def roleable_class
@@ -69,18 +76,21 @@ module Rabarber
 
     private
 
-    def create_new_roles(role_names)
-      new_roles = role_names - Rabarber::Role.names
-      new_roles.each { |role_name| Rabarber::Role.create!(name: role_name) }
+    def create_new_roles(role_names, context)
+      new_roles = role_names - Rabarber::Role.where(context.to_h).names
+      new_roles.each { |role_name| Rabarber::Role.create!(name: role_name, **context.to_h) }
+    end
+
+    def process_context(context)
+      Rabarber::Core::Context.new(context)
     end
 
     def process_role_names(role_names)
       Rabarber::Input::Roles.new(role_names).process
     end
 
-    def delete_roleable_cache
-      # TODO: real context
-      Rabarber::Core::Cache.delete(roleable_id, context: nil)
+    def delete_roleable_cache(context)
+      Rabarber::Core::Cache.delete(roleable_id, context: context)
     end
 
     def roleable_id

--- a/lib/rabarber/models/concerns/has_roles.rb
+++ b/lib/rabarber/models/concerns/has_roles.rb
@@ -15,7 +15,8 @@ module Rabarber
     end
 
     def roles
-      Rabarber::Core::Cache.fetch(roleable_id) { rabarber_roles.names }
+      # TODO: real context
+      Rabarber::Core::Cache.fetch(roleable_id, context: nil) { rabarber_roles.names }
     end
 
     def has_role?(*role_names)
@@ -70,7 +71,8 @@ module Rabarber
     end
 
     def delete_roleable_cache
-      Rabarber::Core::Cache.delete(roleable_id)
+      # TODO: real context
+      Rabarber::Core::Cache.delete(roleable_id, context: nil)
     end
 
     def roleable_id

--- a/lib/rabarber/models/role.rb
+++ b/lib/rabarber/models/role.rb
@@ -4,7 +4,10 @@ module Rabarber
   class Role < ActiveRecord::Base
     self.table_name = "rabarber_roles"
 
-    validates :name, presence: true, uniqueness: true, format: { with: Rabarber::Input::Role::REGEX }, strict: true
+    validates :name,
+              presence: true,
+              uniqueness: { scope: [:context_type, :context_id] },
+              format: { with: Rabarber::Input::Role::REGEX }, strict: true
 
     has_and_belongs_to_many :roleables, join_table: "rabarber_roles_roleables"
 

--- a/lib/rabarber/models/role.rb
+++ b/lib/rabarber/models/role.rb
@@ -8,6 +8,10 @@ module Rabarber
 
     has_and_belongs_to_many :roleables, join_table: "rabarber_roles_roleables"
 
+    def context
+      Rabarber::Core::Context.new({ context_type: context_type, context_id: context_id }, wrap: true)
+    end
+
     class << self
       def names
         pluck(:name).map(&:to_sym)

--- a/lib/rabarber/models/role.rb
+++ b/lib/rabarber/models/role.rb
@@ -9,7 +9,7 @@ module Rabarber
     has_and_belongs_to_many :roleables, join_table: "rabarber_roles_roleables"
 
     def context
-      Rabarber::Core::Context.new({ context_type: context_type, context_id: context_id }, wrap: true)
+      Rabarber::Core::Context.new(context_type: context_type, context_id: context_id)
     end
 
     class << self

--- a/lib/rabarber/models/role.rb
+++ b/lib/rabarber/models/role.rb
@@ -51,7 +51,8 @@ module Rabarber
       private
 
       def delete_roleables_cache(role)
-        Rabarber::Core::Cache.delete(*assigned_to_roleables(role))
+        # TODO: real context
+        Rabarber::Core::Cache.delete(*assigned_to_roleables(role), context: nil)
       end
 
       def assigned_to_roleables(role)

--- a/lib/rabarber/models/role.rb
+++ b/lib/rabarber/models/role.rb
@@ -8,10 +8,6 @@ module Rabarber
 
     has_and_belongs_to_many :roleables, join_table: "rabarber_roles_roleables"
 
-    def context
-      Rabarber::Core::Context.new(context_type: context_type, context_id: context_id)
-    end
-
     class << self
       def names
         pluck(:name).map(&:to_sym)

--- a/lib/rabarber/version.rb
+++ b/lib/rabarber/version.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 module Rabarber
+  # TODO: bump
   VERSION = "2.0.0"
 end

--- a/spec/generators/roles_generator_spec.rb
+++ b/spec/generators/roles_generator_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Rabarber::RolesGenerator do
           def change
             create_table :rabarber_roles do |t|
               t.string :name, null: false, index: { unique: true }
+              t.belongs_to :context, polymorphic: true, index: true
               t.timestamps
             end
 
@@ -62,6 +63,7 @@ RSpec.describe Rabarber::RolesGenerator do
           def change
             create_table :rabarber_roles, id: :uuid do |t|
               t.string :name, null: false, index: { unique: true }
+              t.belongs_to :context, polymorphic: true, index: true, type: :uuid
               t.timestamps
             end
 

--- a/spec/rabarber/audit/events/roles_assigned_spec.rb
+++ b/spec/rabarber/audit/events/roles_assigned_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Rabarber::Audit::Events::RolesAssigned do
-  subject { described_class.trigger(roleable, roles_to_assign: roles_to_assign, current_roles: current_roles) }
+  subject { described_class.trigger(roleable, context: context, roles_to_assign: roles_to_assign, current_roles: current_roles) }
 
+  let(:context) { Rabarber::Core::Context.new(nil) }
   let(:roles_to_assign) { [:admin, :manager] }
   let(:current_roles) { [:admin, :manager, :accountant] }
 
@@ -10,7 +11,7 @@ RSpec.describe Rabarber::Audit::Events::RolesAssigned do
     let(:roleable) { User.create }
 
     it "logs the role assignment" do
-      expect(Rabarber::Audit::Logger).to receive(:log).with(:info, "[Role Assignment] User with id: '#{roleable.id}' has been assigned the following roles: #{roles_to_assign}, current roles: #{current_roles}").and_call_original
+      expect(Rabarber::Audit::Logger).to receive(:log).with(:info, "[Role Assignment] User##{roleable.id} | context: 'Global', assigned roles: #{roles_to_assign}, current roles: #{current_roles}").and_call_original
       subject
     end
   end

--- a/spec/rabarber/audit/events/roles_revoked_spec.rb
+++ b/spec/rabarber/audit/events/roles_revoked_spec.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe Rabarber::Audit::Events::RolesRevoked do
-  subject { described_class.trigger(roleable, roles_to_revoke: roles_to_revoke, current_roles: current_roles) }
+  subject { described_class.trigger(roleable, context: context, roles_to_revoke: roles_to_revoke, current_roles: current_roles) }
 
+  let(:project) { Project.create! }
+  let(:context) { Rabarber::Core::Context.new(project) }
   let(:roles_to_revoke) { [:admin, :manager] }
   let(:current_roles) { [:accountant] }
 
@@ -10,7 +12,7 @@ RSpec.describe Rabarber::Audit::Events::RolesRevoked do
     let(:roleable) { User.create }
 
     it "logs the role revocation" do
-      expect(Rabarber::Audit::Logger).to receive(:log).with(:info, "[Role Revocation] User with id: '#{roleable.id}' has been revoked from the following roles: #{roles_to_revoke}, current roles: #{current_roles}").and_call_original
+      expect(Rabarber::Audit::Logger).to receive(:log).with(:info, "[Role Revocation] User##{roleable.id} | context: 'Project##{project.id}', revoked roles: #{roles_to_revoke}, current roles: #{current_roles}").and_call_original
       subject
     end
   end

--- a/spec/rabarber/audit/events/unauthorized_attempt_spec.rb
+++ b/spec/rabarber/audit/events/unauthorized_attempt_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Rabarber::Audit::Events::UnauthorizedAttempt do
     before { roleable.assign_roles(:admin) }
 
     it "logs the unauthorized attempt" do
-      expect(Rabarber::Audit::Logger).to receive(:log).with(:warn, "[Unauthorized Attempt] User with id: '#{roleable.id}', roles: [:admin] attempted to access '#{path}'").and_call_original
+      expect(Rabarber::Audit::Logger).to receive(:log).with(:warn, "[Unauthorized Attempt] User##{roleable.id} | roles: {'Global'=>[:admin]}, path: '#{path}'").and_call_original
       subject
     end
   end
@@ -20,7 +20,7 @@ RSpec.describe Rabarber::Audit::Events::UnauthorizedAttempt do
     let(:roleable) { nil }
 
     it "logs the unauthorized attempt" do
-      expect(Rabarber::Audit::Logger).to receive(:log).with(:warn, "[Unauthorized Attempt] Unauthenticated user attempted to access '#{path}'").and_call_original
+      expect(Rabarber::Audit::Logger).to receive(:log).with(:warn, "[Unauthorized Attempt] Unauthenticated user | path: '#{path}'").and_call_original
       subject
     end
   end

--- a/spec/rabarber/audit/events/unauthorized_attempt_spec.rb
+++ b/spec/rabarber/audit/events/unauthorized_attempt_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Rabarber::Audit::Events::UnauthorizedAttempt do
     before { roleable.assign_roles(:admin) }
 
     it "logs the unauthorized attempt" do
-      expect(Rabarber::Audit::Logger).to receive(:log).with(:warn, "[Unauthorized Attempt] User##{roleable.id} | roles: {'Global'=>[:admin]}, path: '#{path}'").and_call_original
+      expect(Rabarber::Audit::Logger).to receive(:log).with(:warn, "[Unauthorized Attempt] User##{roleable.id} | path: '#{path}'").and_call_original
       subject
     end
   end

--- a/spec/rabarber/core/cache_spec.rb
+++ b/spec/rabarber/core/cache_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Rabarber::Core::Cache do
     subject { described_class.fetch(id, context: context) { "bar" } }
 
     let(:id) { 42 }
-    let(:context) { { context_type: Project, context_id: 13 } }
+    let(:context) { Rabarber::Core::Context.new(Project) }
 
     let(:default_options) { { expires_in: 1.hour, race_condition_ttl: 5.seconds } }
 
@@ -91,7 +91,7 @@ RSpec.describe Rabarber::Core::Cache do
     subject { described_class.delete(*ids, context: context) }
 
     let(:ids) { [42, 13] }
-    let(:context) { { context_type: Project, context_id: 13 } }
+    let(:context) { Rabarber::Core::Context.new(Project.create!) }
 
     let(:key42) { described_class.key_for(42, context) }
     let(:key13) { described_class.key_for(13, context) }
@@ -168,7 +168,7 @@ RSpec.describe Rabarber::Core::Cache do
 
   describe ".clear" do
     let(:ids) { [1, 2, 42] }
-    let(:context) { { context_type: Project, context_id: 13 } }
+    let(:context) { Rabarber::Core::Context.new(nil) }
 
     let(:keys) { ids.map { |id| described_class.key_for(id, context) } }
 
@@ -194,8 +194,8 @@ RSpec.describe Rabarber::Core::Cache do
     subject { described_class.key_for(id, context) }
 
     let(:id) { 42 }
-    let(:context) { { context_type: Project, context_id: 13 } }
+    let(:context) { Rabarber::Core::Context.new(Project.create!) }
 
-    it { is_expected.to eq("rabarber:d73ef780207217a00893eb441ead77adf81846d9cc46c57991856f8b3c7f00b7") }
+    it { is_expected.to eq("rabarber:56f439b8bd1b369b59fc1412a88fd66a1c5b03844d343f0bfe0d70bd996e9ec0") }
   end
 end

--- a/spec/rabarber/core/context_spec.rb
+++ b/spec/rabarber/core/context_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.describe Rabarber::Core::Context do
+  describe "#initialize" do
+    subject { described_class.new(context) }
+
+    let(:context) { Project.create! }
+
+    it "processes the input context" do
+      expect(Rabarber::Input::Context).to receive(:new).with(context).and_call_original
+      subject
+    end
+  end
+
+  describe "#to_h" do
+    subject { described_class.new(context).to_h }
+
+    let(:context) { Project.create! }
+
+    it "returns the processed context" do
+      expect(subject).to eq(context_type: "Project", context_id: context.id)
+    end
+  end
+
+  describe "#to_s" do
+    subject { described_class.new(context).to_s }
+
+    context "when context is global" do
+      let(:context) { nil }
+
+      it "returns 'Global'" do
+        expect(subject).to eq("Global")
+      end
+    end
+
+    context "when context is a type" do
+      let(:context) { Project }
+
+      it "returns the context type" do
+        expect(subject).to eq("Project")
+      end
+    end
+
+    context "when context is an instance" do
+      let(:context) { Project.create! }
+
+      it "returns the context type and id" do
+        expect(subject).to eq("Project##{context.id}")
+      end
+    end
+
+    context "when context is unexpected" do
+      let(:context) { 42 }
+
+      before { allow_any_instance_of(Rabarber::Input::Context).to receive(:process).and_return(42) }
+
+      it "raises an error" do
+        expect { subject }.to raise_error("Unexpected context: 42")
+      end
+    end
+  end
+end

--- a/spec/rabarber/core/context_spec.rb
+++ b/spec/rabarber/core/context_spec.rb
@@ -2,10 +2,9 @@
 
 RSpec.describe Rabarber::Core::Context do
   describe "#initialize" do
-    subject { described_class.new(context, wrap: wrap) }
+    subject { described_class.new(context) }
 
-    context "when wrap is false" do
-      let(:wrap) { false }
+    context "when context is not hash" do
       let(:context) { Project.create! }
 
       it "processes the input context" do
@@ -14,8 +13,7 @@ RSpec.describe Rabarber::Core::Context do
       end
     end
 
-    context "when wrap is true" do
-      let(:wrap) { true }
+    context "when context is a hash" do
       let(:context) { { context_type: "Project", context_id: nil } }
 
       it "does not process the input context" do

--- a/spec/rabarber/core/context_spec.rb
+++ b/spec/rabarber/core/context_spec.rb
@@ -4,22 +4,11 @@ RSpec.describe Rabarber::Core::Context do
   describe "#initialize" do
     subject { described_class.new(context) }
 
-    context "when context is not hash" do
-      let(:context) { Project.create! }
+    let(:context) { Project.create! }
 
-      it "processes the input context" do
-        expect(Rabarber::Input::Context).to receive(:new).with(context).and_call_original
-        expect(subject.context).to eq(context_type: "Project", context_id: context.id)
-      end
-    end
-
-    context "when context is a hash" do
-      let(:context) { { context_type: "Project", context_id: nil } }
-
-      it "does not process the input context" do
-        expect(Rabarber::Input::Context).not_to receive(:new)
-        expect(subject.context).to eq(context)
-      end
+    it "processes the input context" do
+      expect(Rabarber::Input::Context).to receive(:new).with(context).and_call_original
+      expect(subject.context).to eq(context_type: "Project", context_id: context.id)
     end
   end
 

--- a/spec/rabarber/core/context_spec.rb
+++ b/spec/rabarber/core/context_spec.rb
@@ -2,13 +2,26 @@
 
 RSpec.describe Rabarber::Core::Context do
   describe "#initialize" do
-    subject { described_class.new(context) }
+    subject { described_class.new(context, wrap: wrap) }
 
-    let(:context) { Project.create! }
+    context "when wrap is false" do
+      let(:wrap) { false }
+      let(:context) { Project.create! }
 
-    it "processes the input context" do
-      expect(Rabarber::Input::Context).to receive(:new).with(context).and_call_original
-      subject
+      it "processes the input context" do
+        expect(Rabarber::Input::Context).to receive(:new).with(context).and_call_original
+        expect(subject.context).to eq(context_type: "Project", context_id: context.id)
+      end
+    end
+
+    context "when wrap is true" do
+      let(:wrap) { true }
+      let(:context) { { context_type: "Project", context_id: nil } }
+
+      it "does not process the input context" do
+        expect(Rabarber::Input::Context).not_to receive(:new)
+        expect(subject.context).to eq(context)
+      end
     end
   end
 

--- a/spec/rabarber/input/context_spec.rb
+++ b/spec/rabarber/input/context_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe Rabarber::Input::Context do
       context "when a class is given" do
         let(:context) { Project }
 
-        it { is_expected.to eq(context_type: Project, context_id: nil) }
+        it { is_expected.to eq(context_type: "Project", context_id: nil) }
       end
 
       context "when an instance of ActiveRecord::Base is given" do
         let(:context) { Project.create! }
 
-        it { is_expected.to eq(context_type: Project, context_id: context.id) }
+        it { is_expected.to eq(context_type: "Project", context_id: context.id) }
       end
 
       context "when nil is given" do

--- a/spec/rabarber/input/context_spec.rb
+++ b/spec/rabarber/input/context_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe Rabarber::Input::Context do
+  describe "#process" do
+    subject { described_class.new(context).process }
+
+    context "when the given context is valid" do
+      context "when a class is given" do
+        let(:context) { Project }
+
+        it { is_expected.to eq(context_type: Project, context_id: nil) }
+      end
+
+      context "when an instance of ActiveRecord::Base is given" do
+        let(:context) { Project.create! }
+
+        it { is_expected.to eq(context_type: Project, context_id: context.id) }
+      end
+
+      context "when nil is given" do
+        let(:context) { nil }
+
+        it { is_expected.to eq(context_type: nil, context_id: nil) }
+      end
+    end
+
+    context "when the given context is invalid" do
+      [1, ["context"], "context", "", :context, {}, :""].each do |invalid_context|
+        let(:context) { invalid_context }
+
+        it "raises an error when '#{invalid_context}' is given as an action name" do
+          expect { subject }.to raise_error(
+            Rabarber::InvalidArgumentError, "Context must be a Class or an instance of ActiveRecord::Base"
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/rabarber/models/concerns/has_roles_spec.rb
+++ b/spec/rabarber/models/concerns/has_roles_spec.rb
@@ -122,8 +122,11 @@ RSpec.describe Rabarber::HasRoles do
         end
 
         it "logs the role assignment" do
+          # TODO: real context
+          context_double = instance_double(Rabarber::Core::Context)
+          allow(Rabarber::Core::Context).to receive(:new).with(nil).and_return(context_double)
           expect(Rabarber::Audit::Events::RolesAssigned).to receive(:trigger)
-            .with(user, roles_to_assign: roles, current_roles: roles).and_call_original
+            .with(user, context: context_double, roles_to_assign: roles, current_roles: roles).and_call_original
           subject
         end
 
@@ -147,8 +150,11 @@ RSpec.describe Rabarber::HasRoles do
         end
 
         it "logs the role assignment" do
+          # TODO: real context
+          context_double = instance_double(Rabarber::Core::Context)
+          allow(Rabarber::Core::Context).to receive(:new).with(nil).and_return(context_double)
           expect(Rabarber::Audit::Events::RolesAssigned).to receive(:trigger)
-            .with(user, roles_to_assign: roles, current_roles: roles).and_call_original
+            .with(user, context: context_double, roles_to_assign: roles, current_roles: roles).and_call_original
           subject
         end
 
@@ -170,8 +176,11 @@ RSpec.describe Rabarber::HasRoles do
         end
 
         it "logs the role assignment" do
+          # TODO: real context
+          context_double = instance_double(Rabarber::Core::Context)
+          allow(Rabarber::Core::Context).to receive(:new).with(nil).and_return(context_double)
           expect(Rabarber::Audit::Events::RolesAssigned).to receive(:trigger)
-            .with(user, roles_to_assign: roles, current_roles: roles).and_call_original
+            .with(user, context: context_double, roles_to_assign: roles, current_roles: roles).and_call_original
           subject
         end
 
@@ -226,8 +235,11 @@ RSpec.describe Rabarber::HasRoles do
         end
 
         it "logs the role assignment" do
+          # TODO: real context
+          context_double = instance_double(Rabarber::Core::Context)
+          allow(Rabarber::Core::Context).to receive(:new).with(nil).and_return(context_double)
           expect(Rabarber::Audit::Events::RolesAssigned).to receive(:trigger)
-            .with(user, roles_to_assign: roles, current_roles: roles).and_call_original
+            .with(user, context: context_double, roles_to_assign: roles, current_roles: roles).and_call_original
           subject
         end
 
@@ -272,8 +284,11 @@ RSpec.describe Rabarber::HasRoles do
         end
 
         it "logs the role assignment" do
+          # TODO: real context
+          context_double = instance_double(Rabarber::Core::Context)
+          allow(Rabarber::Core::Context).to receive(:new).with(nil).and_return(context_double)
           expect(Rabarber::Audit::Events::RolesAssigned).to receive(:trigger)
-            .with(user, roles_to_assign: [roles.first], current_roles: [roles.first]).and_call_original
+            .with(user, context: context_double, roles_to_assign: [roles.first], current_roles: [roles.first]).and_call_original
           subject
         end
 
@@ -331,8 +346,11 @@ RSpec.describe Rabarber::HasRoles do
       end
 
       it "logs the role revocation" do
+        # TODO: real context
+        context_double = instance_double(Rabarber::Core::Context)
+        allow(Rabarber::Core::Context).to receive(:new).with(nil).and_return(context_double)
         expect(Rabarber::Audit::Events::RolesRevoked).to receive(:trigger)
-          .with(user, roles_to_revoke: roles, current_roles: []).and_call_original
+          .with(user, context: context_double, roles_to_revoke: roles, current_roles: []).and_call_original
         subject
       end
 
@@ -371,8 +389,11 @@ RSpec.describe Rabarber::HasRoles do
       end
 
       it "logs the role revocation" do
+        # TODO: real context
+        context_double = instance_double(Rabarber::Core::Context)
+        allow(Rabarber::Core::Context).to receive(:new).with(nil).and_return(context_double)
         expect(Rabarber::Audit::Events::RolesRevoked).to receive(:trigger)
-          .with(user, roles_to_revoke: roles.first(1), current_roles: []).and_call_original
+          .with(user, context: context_double, roles_to_revoke: roles.first(1), current_roles: []).and_call_original
         subject
       end
 

--- a/spec/rabarber/models/concerns/has_roles_spec.rb
+++ b/spec/rabarber/models/concerns/has_roles_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe Rabarber::HasRoles do
 
     shared_examples_for "it caches user roles" do
       it "caches user roles" do
-        expect(Rabarber::Core::Cache).to receive(:fetch).with(user.id) do |&block|
+        # TODO: real context
+        expect(Rabarber::Core::Cache).to receive(:fetch).with(user.id, context: nil) do |&block|
           result = block.call
           expect(result).to match_array(roles)
           result
@@ -90,7 +91,8 @@ RSpec.describe Rabarber::HasRoles do
 
   shared_examples_for "it deletes the cache" do
     it "deletes the cache" do
-      expect(Rabarber::Core::Cache).to receive(:delete).with(user.id).and_call_original
+      # TODO: real context
+      expect(Rabarber::Core::Cache).to receive(:delete).with(user.id, context: nil).and_call_original
       subject
     end
   end

--- a/spec/rabarber/models/role_spec.rb
+++ b/spec/rabarber/models/role_spec.rb
@@ -42,8 +42,7 @@ RSpec.describe Rabarber::Role do
     let(:context_double) { instance_double(Rabarber::Core::Context) }
 
     before do
-      allow(Rabarber::Core::Context).to receive(:new)
-        .with({ context_type: "Project", context_id: 42 }, wrap: true).and_return(context_double)
+      allow(Rabarber::Core::Context).to receive(:new).with(context_type: "Project", context_id: 42).and_return(context_double)
     end
 
     it "returns the context object" do

--- a/spec/rabarber/models/role_spec.rb
+++ b/spec/rabarber/models/role_spec.rb
@@ -35,6 +35,22 @@ RSpec.describe Rabarber::Role do
     end
   end
 
+  describe "#context" do
+    subject { role.context }
+
+    let(:role) { described_class.create!(name: "admin", context_type: "Project", context_id: 42) }
+    let(:context_double) { instance_double(Rabarber::Core::Context) }
+
+    before do
+      allow(Rabarber::Core::Context).to receive(:new)
+        .with({ context_type: "Project", context_id: 42 }, wrap: true).and_return(context_double)
+    end
+
+    it "returns the context object" do
+      expect(subject).to eq(context_double)
+    end
+  end
+
   describe ".names" do
     subject { described_class.names }
 

--- a/spec/rabarber/models/role_spec.rb
+++ b/spec/rabarber/models/role_spec.rb
@@ -35,21 +35,6 @@ RSpec.describe Rabarber::Role do
     end
   end
 
-  describe "#context" do
-    subject { role.context }
-
-    let(:role) { described_class.create!(name: "admin", context_type: "Project", context_id: 42) }
-    let(:context_double) { instance_double(Rabarber::Core::Context) }
-
-    before do
-      allow(Rabarber::Core::Context).to receive(:new).with(context_type: "Project", context_id: 42).and_return(context_double)
-    end
-
-    it "returns the context object" do
-      expect(subject).to eq(context_double)
-    end
-  end
-
   describe ".names" do
     subject { described_class.names }
 

--- a/spec/rabarber/models/role_spec.rb
+++ b/spec/rabarber/models/role_spec.rb
@@ -122,7 +122,8 @@ RSpec.describe Rabarber::Role do
       it { is_expected.to be true }
 
       it "clears the cache" do
-        expect(Rabarber::Core::Cache).to receive(:delete).with(user.id) if role_assigned
+        # TODO: real context
+        expect(Rabarber::Core::Cache).to receive(:delete).with(user.id, context: nil) if role_assigned
         subject
       end
 
@@ -256,7 +257,8 @@ RSpec.describe Rabarber::Role do
       it { is_expected.to be true }
 
       it "clears the cache" do
-        expect(Rabarber::Core::Cache).to receive(:delete).with(user.id) if role_assigned
+        # TODO: real context
+        expect(Rabarber::Core::Cache).to receive(:delete).with(user.id, context: nil) if role_assigned
         subject
       end
 

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -9,3 +9,5 @@ class User < ApplicationRecord
 end
 
 class Client < ApplicationRecord; end
+
+class Project < ApplicationRecord; end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -10,7 +10,7 @@ ActiveRecord::Schema.define do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["context_type", "context_id"], name: "index_rabarber_roles_on_context"
-    t.index ["name"], name: "index_rabarber_roles_on_name", unique: true
+    t.index ["name", "context_type", "context_id"], name: "index_rabarber_roles_on_name_and_context_type_and_context_id", unique: true
   end
 
   create_table "rabarber_roles_roleables", id: false, force: :cascade do |t|

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -5,8 +5,11 @@ ActiveRecord::Schema.define do
 
   create_table "rabarber_roles", force: :cascade do |t|
     t.string "name", null: false
+    t.string "context_type"
+    t.integer "context_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["context_type", "context_id"], name: "index_rabarber_roles_on_context"
     t.index ["name"], name: "index_rabarber_roles_on_name", unique: true
   end
 

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -26,6 +26,11 @@ ActiveRecord::Schema.define do
     t.datetime "updated_at", null: false
   end
 
+  create_table "projects", force: true do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   add_foreign_key "rabarber_roles_roleables", "rabarber_roles", column: "role_id"
   add_foreign_key "rabarber_roles_roleables", "users", column: "roleable_id"
 end


### PR DESCRIPTION
The idea is to allow roles to be defined within some context (can be used for multi-tenancy and other cases where roles are not global), e.g.:

```rb
user.assign_roles(:admin, context: project)
user.assign_roles(:admin, context: Project)
user.assign_roles(:admin) # context is nil by default
```

The context can be an instance of an `ActiveRecord` model, a class, or `nil` (meaning the global context).

And this is how context could be used within the authorization rules:

```rb
grant_access roles: :admin, context: :project
grant_access roles: :admin, context: -> { Project.find(params[:id]) }
grant_access roles: :admin, context: Project
grant_access roles: :admin # context is nil by default
```