### PR TITLE
Context / Multi-tenancy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,9 @@ Rails/ApplicationController:
 Rails/ApplicationRecord:
   Enabled: false
 
+Rails/FilePath:
+  Enabled: false
+
 Rails/RakeEnvironment:
   Enabled: false
 
@@ -54,9 +57,6 @@ RSpec/ContextWording:
   Enabled: false
 
 RSpec/ExampleLength:
-  Enabled: false
-
-RSpec/FilePath:
   Enabled: false
 
 RSpec/IndexedLet:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,6 +56,9 @@ RSpec/ExampleLength:
 RSpec/FilePath:
   Enabled: false
 
+RSpec/IndexedLet:
+  Enabled: false
+
 RSpec/MessageChain:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,9 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Enabled: false
 
+Metrics/ParameterLists:
+  Enabled: false
+
 Naming/PredicateName:
   Enabled: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- TODO: describe new version -->
 ## v2.1.0
 
 ### Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
-<!-- TODO: describe new version -->
+## v3.0.0
+
+### Breaking:
+
+- Changed Rabarber roles table structure
+
+To upgrade to v3.0.0, please refer to the [migration guide](https://github.com/enjaku4/rabarber/discussions/58)
+
+### Features:
+
+- Introduced the ability to define and authorize roles within a specific context
+
+### Misc:
+
+- Revised log messages in the audit trail for clarity and conciseness
+
 ## v2.1.0
 
 ### Features:
@@ -13,7 +28,7 @@
 - Replaced `when_unauthorized` configuration option with an overridable controller method
 - Renamed `Rabarber::Role.assignees_for` method to `Rabarber::Role.assignees`
 
-To upgrade to v2.0.0, please refer to the [migration guide](https://github.com/enjaku4/rabarber/discussions/52).
+To upgrade to v2.0.0, please refer to the [migration guide](https://github.com/enjaku4/rabarber/discussions/52)
 
 ### Features:
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- TODO: describe context feature -->
+
 # Rabarber: Simplified Authorization for Rails
 
 [![Gem Version](https://badge.fury.io/rb/rabarber.svg)](http://badge.fury.io/rb/rabarber)

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ end
 
 Rabarber supports multi-tenancy by providing a context feature. This allows you to define and authorize roles and rules within a specific context.
 
-Every Rabarber method that accepts roles can also accept a context as an additional keyword argument. By default, the context is set to nil, meaning the roles are global. Thus, all examples from other sections of this README are valid for global roles, but you can still use the context with them if needed. Apart from being global, the context can be an instance of ActiveRecord model or a class.
+Every Rabarber method that accepts roles can also accept a context as an additional keyword argument. By default, the context is set to `nil`, meaning the roles are global. Thus, all examples from other sections of this README are valid for global roles. Apart from being global, the context can be an instance of ActiveRecord model or a class.
 
 E.g., consider a model named Project, where each project has its owner and regular members. Roles can be defined like this:
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ end
 
 This adds the following methods:
 
-**`#assign_roles(*roles, create_new: true)`**
+**`#assign_roles(*roles, context: nil, create_new: true)`**
 
 To assign roles, use:
 
@@ -129,7 +129,7 @@ user.assign_roles(:accountant, :marketer, create_new: false)
 ```
 The method returns an array of roles assigned to the user.
 
-**`#revoke_roles(*roles)`**
+**`#revoke_roles(*roles, context: nil)`**
 
 To revoke roles, use:
 
@@ -140,7 +140,7 @@ If the user doesn't have the role you want to revoke, it will be ignored.
 
 The method returns an array of roles assigned to the user.
 
-**`#has_role?(*roles)`**
+**`#has_role?(*roles, context: nil)`**
 
 To check whether the user has a role, use:
 
@@ -150,9 +150,9 @@ user.has_role?(:accountant, :marketer)
 
 It returns `true` if the user has at least one role and `false` otherwise.
 
-**`#roles`**
+**`#roles(context: nil)`**
 
-To get all the roles assigned to the user, use:
+To get the list of roles assigned to the user, use:
 
 ```rb
 user.roles
@@ -162,7 +162,7 @@ user.roles
 
 To manipulate roles directly, you can use `Rabarber::Role` methods:
 
-**`.add(role_name)`**
+**`.add(role_name, context: nil)`**
 
 To add a new role, use:
 
@@ -172,7 +172,7 @@ Rabarber::Role.add(:admin)
 
 This will create a new role with the specified name and return `true`. If the role already exists, it will return `false`.
 
-**`.rename(old_role_name, new_role_name, force: false)`**
+**`.rename(old_role_name, new_role_name, context: nil, force: false)`**
 
 To rename a role, use:
 
@@ -186,7 +186,7 @@ The method won't rename the role and will return `false` if it is assigned to an
 Rabarber::Role.rename(:admin, :administrator, force: true)
 ```
 
-**`.remove(role_name, force: false)`**
+**`.remove(role_name, context: nil, force: false)`**
 
 To remove a role, use:
 
@@ -201,15 +201,15 @@ The method won't remove the role and will return `false` if it is assigned to an
 Rabarber::Role.remove(:admin, force: true)
 ```
 
-**`.names`**
+**`.names(context: nil)`**
 
-If you need to list all the role names available in your application, use:
+If you need to list the role names available in your application, use:
 
 ```rb
 Rabarber::Role.names
 ```
 
-**`.assignees(role_name)`**
+**`.assignees(role_name, context: nil)`**
 
 To get all the users to whom the role is assigned, use:
 
@@ -227,7 +227,7 @@ class ApplicationController < ActionController::Base
   # ...
 end
 ```
-This adds `.grant_access(action: nil, roles: nil, if: nil, unless: nil)` method which allows you to define the authorization rules.
+This adds `.grant_access(action: nil, roles: nil, context: nil, if: nil, unless: nil)` method which allows you to define the authorization rules.
 
 The most basic usage of the method is as follows:
 
@@ -424,7 +424,19 @@ class ProjectsController < ApplicationController
 end
 ```
 
-It's important to note that role names are not unique globally but are unique within the scope of their context. E.g., `user.assign_roles(:admin, context: Project)` and `user.assign_roles(:admin)` assign different roles to the user.
+It's important to note that role names are not unique globally but are unique within the scope of their context. E.g., `user.assign_roles(:admin, context: Project)` and `user.assign_roles(:admin)` assign different roles to the user. The same as `Rabarber::Role.add(:admin, context: Project)` and `Rabarber::Role.add(:admin)` create different roles.
+
+If you want to see all the roles assigned to a user within a specific context, you can use:
+
+```rb
+  user.roles(context: project)
+```
+
+Or if you want to get all the roles available in a specific context, you can use:
+
+```rb
+  Rabarber::Role.names(context: Project)
+```
 
 ## When Unauthorized
 

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Rabarber supports multi-tenancy by providing a context feature. This allows you 
 
 Every Rabarber method that accepts roles can also accept a context as an additional keyword argument. By default, the context is set to `nil`, meaning the roles are global. Thus, all examples from other sections of this README are valid for global roles. Apart from being global, the context can be an instance of ActiveRecord model or a class.
 
-E.g., consider a model named Project, where each project has its owner and regular members. Roles can be defined like this:
+E.g., consider a model named `Project`, where each project has its owner and regular members. Roles can be defined like this:
 
 ```rb
   user.assign_roles(:owner, context: project)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This means that `admin` users can access everything in `TicketsController`, whil
   - [Roles](#roles)
   - [Authorization Rules](#authorization-rules)
   - [Dynamic Authorization Rules](#dynamic-authorization-rules)
-  - [Context / Multitenancy](#context--multitenancy)
+  - [Context / Multi-tenancy](#context--multi-tenancy)
   - [When Unauthorized](#when-unauthorized)
   - [Skip Authorization](#skip-authorization)
   - [View Helpers](#view-helpers)
@@ -368,9 +368,9 @@ class InvoicesController < ApplicationController
 end
 ```
 
-## Context / Multitenancy
+## Context / Multi-tenancy
 
-Rabarber supports multitenancy by providing a context feature. This allows you to define and authorize roles and rules within a specific context.
+Rabarber supports multi-tenancy by providing a context feature. This allows you to define and authorize roles and rules within a specific context.
 
 Every Rabarber method that accepts roles can also accept a context as an additional keyword argument. By default, the context is set to nil, meaning the roles are global. Thus, all examples from other sections of this README are valid for global roles, but you can still use the context with them if needed. Apart from being global, the context can be an instance of ActiveRecord model or a class.
 

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Rabarber supports multi-tenancy by providing a context feature. This allows you 
 
 Every Rabarber method that accepts roles can also accept a context as an additional keyword argument. By default, the context is set to nil, meaning the roles are global. Thus, all examples from other sections of this README are valid for global roles, but you can still use the context with them if needed. Apart from being global, the context can be an instance of ActiveRecord model or a class.
 
-E.g., let's say we have a model named `Project`, and each project has its owner and regular members. We can define the roles like this:
+E.g., consider a model named Project, where each project has its owner and regular members. Roles can be defined like this:
 
 ```rb
   user.assign_roles(:owner, context: project)
@@ -388,13 +388,13 @@ Then the roles can be verified:
   another_user.has_role?(:member, context: project)
 ```
 
-We can also add a role using a class as a context. Let's say there are project admins who can manage all projects:
+A role can also be added using a class as a context, e.g., for project admins who can manage all projects:
 
 ```rb
   user.assign_roles(:admin, context: Project)
 ```
 
-And then verify the role:
+And then it can also be verified:
 
 ```rb
   user.has_role?(:admin, context: Project)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Gem Version](https://badge.fury.io/rb/rabarber.svg)](http://badge.fury.io/rb/rabarber)
 [![Github Actions badge](https://github.com/enjaku4/rabarber/actions/workflows/ci.yml/badge.svg)](https://github.com/enjaku4/rabarber/actions/workflows/ci.yml)
 
-Rabarber is a role-based authorization library for Ruby on Rails, primarily designed for use in the web layer of your application but not limited to that. It provides a set of tools for managing user roles and defining authorization rules, along with audit logging for enhanced security.
+Rabarber is a role-based authorization library for Ruby on Rails. It provides a set of tools for managing user roles and defining authorization rules, supports multi-tenancy and comes with audit logging for enhanced security.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -424,6 +424,8 @@ class ProjectsController < ApplicationController
 end
 ```
 
+It's important to note that role names are not unique globally but are unique within the scope of their context. E.g., `user.assign_roles(:admin, context: Project)` and `user.assign_roles(:admin)` assign different roles to the user.
+
 ## When Unauthorized
 
 By default, in the event of an unauthorized attempt, Rabarber redirects the user back if the request format is HTML (with fallback to the root path), and returns a 401 (Unauthorized) status code otherwise.

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "bundler/setup"
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 

--- a/lib/generators/rabarber/roles_generator.rb
+++ b/lib/generators/rabarber/roles_generator.rb
@@ -2,6 +2,8 @@
 
 require "rails/generators/migration"
 
+# TODO: is seamless migration to the new table structure possible?
+
 module Rabarber
   class RolesGenerator < Rails::Generators::Base
     include Rails::Generators::Migration

--- a/lib/generators/rabarber/roles_generator.rb
+++ b/lib/generators/rabarber/roles_generator.rb
@@ -2,8 +2,6 @@
 
 require "rails/generators/migration"
 
-# TODO: seamless migration to the new table structure is not possible, deal with it
-
 module Rabarber
   class RolesGenerator < Rails::Generators::Base
     include Rails::Generators::Migration

--- a/lib/generators/rabarber/roles_generator.rb
+++ b/lib/generators/rabarber/roles_generator.rb
@@ -2,7 +2,7 @@
 
 require "rails/generators/migration"
 
-# TODO: is seamless migration to the new table structure possible?
+# TODO: seamless migration to the new table structure is not possible, deal with it
 
 module Rabarber
   class RolesGenerator < Rails::Generators::Base

--- a/lib/generators/rabarber/templates/create_rabarber_roles.rb.erb
+++ b/lib/generators/rabarber/templates/create_rabarber_roles.rb.erb
@@ -3,9 +3,12 @@
 class CreateRabarberRoles < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version.to_s %>]
   def change
     create_table :rabarber_roles<%= ", id: :uuid" if options[:uuid] %> do |t|
-      t.string :name, null: false, index: { unique: true }
+      t.string :name, null: false
+      t.belongs_to :context, polymorphic: true, index: true<%= ", type: :uuid" if options[:uuid] %>
       t.timestamps
     end
+
+    add_index :rabarber_roles, [:name, :context_type, :context_id], unique: true
 
     create_table :rabarber_roles_roleables, id: false do |t|
       t.belongs_to :role, null: false, index: true, foreign_key: { to_table: :rabarber_roles }<%= ", type: :uuid" if options[:uuid] %>

--- a/lib/rabarber.rb
+++ b/lib/rabarber.rb
@@ -8,6 +8,7 @@ require "active_support"
 
 require_relative "rabarber/input/base"
 require_relative "rabarber/input/action"
+require_relative "rabarber/input/context"
 require_relative "rabarber/input/dynamic_rule"
 require_relative "rabarber/input/role"
 require_relative "rabarber/input/roles"

--- a/lib/rabarber.rb
+++ b/lib/rabarber.rb
@@ -8,6 +8,7 @@ require "active_support"
 
 require_relative "rabarber/input/base"
 require_relative "rabarber/input/action"
+require_relative "rabarber/input/authorization_context"
 require_relative "rabarber/input/context"
 require_relative "rabarber/input/dynamic_rule"
 require_relative "rabarber/input/role"

--- a/lib/rabarber/audit/events/base.rb
+++ b/lib/rabarber/audit/events/base.rb
@@ -34,28 +34,27 @@ module Rabarber
         end
 
         def message
+          # TODO: it seems the log messages will be changed significantly, worth mentioning in changelog
           raise NotImplementedError
         end
 
         def identity
-          roleable_identity(with_roles: identity_with_roles?)
-        end
-
-        def identity_with_roles?
-          raise NotImplementedError
-        end
-
-        def roleable_identity(with_roles:)
           if roleable
             model_name = roleable.model_name.human
-            primary_key = roleable.class.primary_key
-            roleable_id = roleable.public_send(primary_key)
+            roleable_id = roleable.public_send(roleable.class.primary_key)
 
-            roles = with_roles ? ", roles: #{roleable.roles}" : ""
-
-            "#{model_name} with #{primary_key}: '#{roleable_id}'#{roles}"
+            "#{model_name}##{roleable_id}"
           else
             "Unauthenticated #{Rabarber::HasRoles.roleable_class.model_name.human.downcase}"
+          end
+        end
+
+        def human_context
+          case context
+          in { context_type: nil, context_id: nil } then "Global"
+          in { context_type: context_type, context_id: nil } then context_type
+          in { context_type: context_type, context_id: context_id } then "#{context_type}##{context_id}"
+          else raise "Unexpected context: #{context}"
           end
         end
       end

--- a/lib/rabarber/audit/events/base.rb
+++ b/lib/rabarber/audit/events/base.rb
@@ -34,7 +34,6 @@ module Rabarber
         end
 
         def message
-          # TODO: it seems the log messages will be changed significantly, worth mentioning in changelog
           raise NotImplementedError
         end
 

--- a/lib/rabarber/audit/events/base.rb
+++ b/lib/rabarber/audit/events/base.rb
@@ -39,13 +39,13 @@ module Rabarber
         end
 
         def identity
-          if roleable
+          if roleable.is_a?(Rabarber::Core::NullRoleable)
+            "Unauthenticated #{Rabarber::HasRoles.roleable_class.model_name.human.downcase}"
+          else
             model_name = roleable.model_name.human
             roleable_id = roleable.public_send(roleable.class.primary_key)
 
             "#{model_name}##{roleable_id}"
-          else
-            "Unauthenticated #{Rabarber::HasRoles.roleable_class.model_name.human.downcase}"
           end
         end
 

--- a/lib/rabarber/audit/events/roles_assigned.rb
+++ b/lib/rabarber/audit/events/roles_assigned.rb
@@ -15,7 +15,7 @@ module Rabarber
         end
 
         def message
-          "[Role Assignment] #{identity} | context: '#{human_context}', assigned roles: #{roles_to_assign}, current roles: #{current_roles}"
+          "[Role Assignment] #{identity} | context: #{human_context} | assigned: #{roles_to_assign} | current: #{current_roles}"
         end
 
         def context

--- a/lib/rabarber/audit/events/roles_assigned.rb
+++ b/lib/rabarber/audit/events/roles_assigned.rb
@@ -15,11 +15,11 @@ module Rabarber
         end
 
         def message
-          "[Role Assignment] #{identity} has been assigned the following roles: #{roles_to_assign}, current roles: #{current_roles}"
+          "[Role Assignment] #{identity} | context: '#{human_context}', assigned roles: #{roles_to_assign}, current roles: #{current_roles}"
         end
 
-        def identity_with_roles?
-          false
+        def context
+          specifics.fetch(:context)
         end
 
         def roles_to_assign

--- a/lib/rabarber/audit/events/roles_revoked.rb
+++ b/lib/rabarber/audit/events/roles_revoked.rb
@@ -15,11 +15,11 @@ module Rabarber
         end
 
         def message
-          "[Role Revocation] #{identity} has been revoked from the following roles: #{roles_to_revoke}, current roles: #{current_roles}"
+          "[Role Revocation] #{identity} | context: '#{human_context}', revoked roles: #{roles_to_revoke}, current roles: #{current_roles}"
         end
 
-        def identity_with_roles?
-          false
+        def context
+          specifics.fetch(:context)
         end
 
         def roles_to_revoke

--- a/lib/rabarber/audit/events/roles_revoked.rb
+++ b/lib/rabarber/audit/events/roles_revoked.rb
@@ -15,7 +15,7 @@ module Rabarber
         end
 
         def message
-          "[Role Revocation] #{identity} | context: '#{human_context}', revoked roles: #{roles_to_revoke}, current roles: #{current_roles}"
+          "[Role Revocation] #{identity} | context: #{human_context} | revoked: #{roles_to_revoke} | current: #{current_roles}"
         end
 
         def context

--- a/lib/rabarber/audit/events/unauthorized_attempt.rb
+++ b/lib/rabarber/audit/events/unauthorized_attempt.rb
@@ -15,7 +15,7 @@ module Rabarber
         end
 
         def message
-          "[Unauthorized Attempt] #{identity} | request: #{request_method} '#{path}'"
+          "[Unauthorized Attempt] #{identity} | request: #{request_method} #{path}"
         end
 
         def path

--- a/lib/rabarber/audit/events/unauthorized_attempt.rb
+++ b/lib/rabarber/audit/events/unauthorized_attempt.rb
@@ -14,6 +14,7 @@ module Rabarber
           :warn
         end
 
+        # TODO: add request method to the message
         def message
           "[Unauthorized Attempt] #{identity} | path: '#{path}'"
         end

--- a/lib/rabarber/audit/events/unauthorized_attempt.rb
+++ b/lib/rabarber/audit/events/unauthorized_attempt.rb
@@ -15,11 +15,7 @@ module Rabarber
         end
 
         def message
-          "[Unauthorized Attempt] #{identity} attempted to access '#{path}'"
-        end
-
-        def identity_with_roles?
-          true
+          "[Unauthorized Attempt] #{identity} | path: '#{path}'"
         end
 
         def path

--- a/lib/rabarber/audit/events/unauthorized_attempt.rb
+++ b/lib/rabarber/audit/events/unauthorized_attempt.rb
@@ -14,13 +14,16 @@ module Rabarber
           :warn
         end
 
-        # TODO: add request method to the message
         def message
-          "[Unauthorized Attempt] #{identity} | path: '#{path}'"
+          "[Unauthorized Attempt] #{identity} | request: #{request_method} '#{path}'"
         end
 
         def path
           specifics.fetch(:path)
+        end
+
+        def request_method
+          specifics.fetch(:request_method)
         end
       end
     end

--- a/lib/rabarber/controllers/concerns/authorization.rb
+++ b/lib/rabarber/controllers/concerns/authorization.rb
@@ -15,13 +15,15 @@ module Rabarber
         skip_before_action :verify_access, **options
       end
 
-      def grant_access(action: nil, roles: nil, if: nil, unless: nil)
+      # TODO: it is difficult or even impossible to pass an ActiveRecord object as a context, the method must be able to receive a symbol or a lambda
+      def grant_access(action: nil, roles: nil, context: nil, if: nil, unless: nil)
         dynamic_rule, negated_dynamic_rule = binding.local_variable_get(:if), binding.local_variable_get(:unless)
 
         Rabarber::Core::Permissions.add(
           self,
           Rabarber::Input::Action.new(action).process,
           Rabarber::Input::Roles.new(roles).process,
+          Rabarber::Input::Context.new(context).process,
           Rabarber::Input::DynamicRule.new(dynamic_rule).process,
           Rabarber::Input::DynamicRule.new(negated_dynamic_rule).process
         )

--- a/lib/rabarber/controllers/concerns/authorization.rb
+++ b/lib/rabarber/controllers/concerns/authorization.rb
@@ -34,7 +34,7 @@ module Rabarber
     def verify_access
       Rabarber::Core::PermissionsIntegrityChecker.new(self.class).run! unless Rails.configuration.eager_load
 
-      return if Rabarber::Core::Permissions.access_granted?(roleable_roles, action_name.to_sym, self)
+      return if Rabarber::Core::Permissions.access_granted?(roleable, action_name.to_sym, self)
 
       Rabarber::Audit::Events::UnauthorizedAttempt.trigger(
         roleable, path: request.path, request_method: request.request_method

--- a/lib/rabarber/controllers/concerns/authorization.rb
+++ b/lib/rabarber/controllers/concerns/authorization.rb
@@ -15,7 +15,6 @@ module Rabarber
         skip_before_action :verify_access, **options
       end
 
-      # TODO: it is difficult or even impossible to pass an ActiveRecord object as a context, the method must be able to receive a symbol or a lambda
       def grant_access(action: nil, roles: nil, context: nil, if: nil, unless: nil)
         dynamic_rule, negated_dynamic_rule = binding.local_variable_get(:if), binding.local_variable_get(:unless)
 
@@ -23,7 +22,7 @@ module Rabarber
           self,
           Rabarber::Input::Action.new(action).process,
           Rabarber::Input::Roles.new(roles).process,
-          Rabarber::Input::Context.new(context).process,
+          Rabarber::Input::AuthorizationContext.new(context).process,
           Rabarber::Input::DynamicRule.new(dynamic_rule).process,
           Rabarber::Input::DynamicRule.new(negated_dynamic_rule).process
         )

--- a/lib/rabarber/controllers/concerns/authorization.rb
+++ b/lib/rabarber/controllers/concerns/authorization.rb
@@ -36,7 +36,9 @@ module Rabarber
 
       return if Rabarber::Core::Permissions.access_granted?(roleable_roles, self.class, action_name.to_sym, self)
 
-      Rabarber::Audit::Events::UnauthorizedAttempt.trigger(roleable, path: request.path)
+      Rabarber::Audit::Events::UnauthorizedAttempt.trigger(
+        roleable, path: request.path, request_method: request.request_method
+      )
 
       when_unauthorized
     end

--- a/lib/rabarber/controllers/concerns/authorization.rb
+++ b/lib/rabarber/controllers/concerns/authorization.rb
@@ -34,7 +34,7 @@ module Rabarber
     def verify_access
       Rabarber::Core::PermissionsIntegrityChecker.new(self.class).run! unless Rails.configuration.eager_load
 
-      return if Rabarber::Core::Permissions.access_granted?(roleable_roles, self.class, action_name.to_sym, self)
+      return if Rabarber::Core::Permissions.access_granted?(roleable_roles, action_name.to_sym, self)
 
       Rabarber::Audit::Events::UnauthorizedAttempt.trigger(
         roleable, path: request.path, request_method: request.request_method

--- a/lib/rabarber/core/access.rb
+++ b/lib/rabarber/core/access.rb
@@ -3,19 +3,19 @@
 module Rabarber
   module Core
     module Access
-      def access_granted?(roles, action, controller_instance)
-        controller_accessible?(roles, controller_instance) || action_accessible?(roles, action, controller_instance)
+      def access_granted?(roleable, action, controller_instance)
+        controller_accessible?(roleable, controller_instance) || action_accessible?(roleable, action, controller_instance)
       end
 
-      def controller_accessible?(roles, controller_instance)
+      def controller_accessible?(roleable, controller_instance)
         controller_rules.any? do |rule_controller, rule|
-          controller_instance.class <= rule_controller && rule.verify_access(roles, controller_instance)
+          controller_instance.class <= rule_controller && rule.verify_access(roleable, controller_instance)
         end
       end
 
-      def action_accessible?(roles, action, controller_instance)
+      def action_accessible?(roleable, action, controller_instance)
         action_rules[controller_instance.class].any? do |rule|
-          rule.action == action && rule.verify_access(roles, controller_instance)
+          rule.action == action && rule.verify_access(roleable, controller_instance)
         end
       end
     end

--- a/lib/rabarber/core/access.rb
+++ b/lib/rabarber/core/access.rb
@@ -3,19 +3,18 @@
 module Rabarber
   module Core
     module Access
-      def access_granted?(roles, controller, action, controller_instance)
-        controller_accessible?(roles, controller, controller_instance) ||
-          action_accessible?(roles, controller, action, controller_instance)
+      def access_granted?(roles, action, controller_instance)
+        controller_accessible?(roles, controller_instance) || action_accessible?(roles, action, controller_instance)
       end
 
-      def controller_accessible?(roles, controller, controller_instance)
+      def controller_accessible?(roles, controller_instance)
         controller_rules.any? do |rule_controller, rule|
-          controller <= rule_controller && rule.verify_access(roles, controller_instance)
+          controller_instance.class <= rule_controller && rule.verify_access(roles, controller_instance)
         end
       end
 
-      def action_accessible?(roles, controller, action, controller_instance)
-        action_rules[controller].any? do |rule|
+      def action_accessible?(roles, action, controller_instance)
+        action_rules[controller_instance.class].any? do |rule|
           rule.action == action && rule.verify_access(roles, controller_instance)
         end
       end

--- a/lib/rabarber/core/access.rb
+++ b/lib/rabarber/core/access.rb
@@ -3,20 +3,20 @@
 module Rabarber
   module Core
     module Access
-      def access_granted?(roles, controller, action, dynamic_rule_receiver)
-        controller_accessible?(roles, controller, dynamic_rule_receiver) ||
-          action_accessible?(roles, controller, action, dynamic_rule_receiver)
+      def access_granted?(roles, controller, action, controller_instance)
+        controller_accessible?(roles, controller, controller_instance) ||
+          action_accessible?(roles, controller, action, controller_instance)
       end
 
-      def controller_accessible?(roles, controller, dynamic_rule_receiver)
+      def controller_accessible?(roles, controller, controller_instance)
         controller_rules.any? do |rule_controller, rule|
-          controller <= rule_controller && rule.verify_access(roles, dynamic_rule_receiver)
+          controller <= rule_controller && rule.verify_access(roles, controller_instance)
         end
       end
 
-      def action_accessible?(roles, controller, action, dynamic_rule_receiver)
+      def action_accessible?(roles, controller, action, controller_instance)
         action_rules[controller].any? do |rule|
-          rule.action == action && rule.verify_access(roles, dynamic_rule_receiver)
+          rule.action == action && rule.verify_access(roles, controller_instance)
         end
       end
     end

--- a/lib/rabarber/core/cache.rb
+++ b/lib/rabarber/core/cache.rb
@@ -11,8 +11,11 @@ module Rabarber
       private_constant :CACHE_PREFIX
 
       def fetch(roleable_id, context:, &block)
-        default_options = { expires_in: 1.hour, race_condition_ttl: 5.seconds }
-        enabled? ? Rails.cache.fetch(key_for(roleable_id, context), **default_options, &block) : yield
+        if enabled?
+          Rails.cache.fetch(key_for(roleable_id, context), expires_in: 1.hour, race_condition_ttl: 5.seconds, &block)
+        else
+          yield
+        end
       end
 
       def delete(*roleable_ids, context:)

--- a/lib/rabarber/core/cache.rb
+++ b/lib/rabarber/core/cache.rb
@@ -1,19 +1,22 @@
 # frozen_string_literal: true
 
+require "digest/sha2"
+
 module Rabarber
   module Core
     module Cache
-      extend self
+      module_function
 
       CACHE_PREFIX = "rabarber"
       private_constant :CACHE_PREFIX
 
-      def fetch(roleable_id, options = { expires_in: 1.hour, race_condition_ttl: 5.seconds }, &block)
-        enabled? ? Rails.cache.fetch(key_for(roleable_id), **options, &block) : yield
+      def fetch(roleable_id, context:, &block)
+        default_options = { expires_in: 1.hour, race_condition_ttl: 5.seconds }
+        enabled? ? Rails.cache.fetch(key_for(roleable_id, context), **default_options, &block) : yield
       end
 
-      def delete(*roleable_ids)
-        keys = roleable_ids.map { |roleable_id| key_for(roleable_id) }
+      def delete(*roleable_ids, context:)
+        keys = roleable_ids.map { |roleable_id| key_for(roleable_id, context) }
         Rails.cache.delete_multi(keys) if enabled? && keys.any?
       end
 
@@ -25,10 +28,8 @@ module Rabarber
         Rails.cache.delete_matched(/^#{CACHE_PREFIX}/o)
       end
 
-      private
-
-      def key_for(id)
-        "#{CACHE_PREFIX}:roles_#{id}"
+      def key_for(id, context)
+        "#{CACHE_PREFIX}:#{Digest::SHA2.hexdigest("#{id}#{context}")}"
       end
     end
   end

--- a/lib/rabarber/core/permissions.rb
+++ b/lib/rabarber/core/permissions.rb
@@ -19,8 +19,8 @@ module Rabarber
       end
 
       class << self
-        def add(controller, action, roles, dynamic_rule, negated_dynamic_rule)
-          rule = Rabarber::Core::Rule.new(action, roles, dynamic_rule, negated_dynamic_rule)
+        def add(controller, action, roles, context, dynamic_rule, negated_dynamic_rule)
+          rule = Rabarber::Core::Rule.new(action, roles, context, dynamic_rule, negated_dynamic_rule)
 
           if action
             instance.storage[:action_rules][controller] += [rule]

--- a/lib/rabarber/core/roleable.rb
+++ b/lib/rabarber/core/roleable.rb
@@ -7,8 +7,8 @@ module Rabarber
         send(Rabarber::Configuration.instance.current_user_method)
       end
 
-      def roleable_roles
-        roleable&.rabarber_roles || Rabarber::Role.none
+      def roleable_roles(context: nil)
+        roleable&.roles(context: context) || []
       end
     end
   end

--- a/lib/rabarber/core/roleable.rb
+++ b/lib/rabarber/core/roleable.rb
@@ -8,7 +8,7 @@ module Rabarber
       end
 
       def roleable_roles
-        roleable&.roles.to_a
+        roleable&.rabarber_roles || Rabarber::Role.none
       end
     end
   end

--- a/lib/rabarber/core/roleable.rb
+++ b/lib/rabarber/core/roleable.rb
@@ -4,11 +4,17 @@ module Rabarber
   module Core
     module Roleable
       def roleable
-        send(Rabarber::Configuration.instance.current_user_method)
+        send(Rabarber::Configuration.instance.current_user_method) || NullRoleable.new
       end
 
       def roleable_roles(context: nil)
-        roleable&.roles(context: context) || []
+        roleable.roles(context: context)
+      end
+    end
+
+    class NullRoleable
+      def roles(context:) # rubocop:disable Lint/UnusedMethodArgument
+        []
       end
     end
   end

--- a/lib/rabarber/core/rule.rb
+++ b/lib/rabarber/core/rule.rb
@@ -37,11 +37,11 @@ module Rabarber
 
         return true if rule.nil?
 
-        result = !!if rule.is_a?(Proc)
-                     controller_instance.instance_exec(&rule)
-                   else
-                     controller_instance.send(rule)
-                   end
+        result = if rule.is_a?(Proc)
+                   controller_instance.instance_exec(&rule)
+                 else
+                   controller_instance.send(rule)
+                 end
 
         is_negated ? !result : result
       end

--- a/lib/rabarber/core/rule.rb
+++ b/lib/rabarber/core/rule.rb
@@ -13,14 +13,16 @@ module Rabarber
         @negated_dynamic_rule = negated_dynamic_rule
       end
 
-      def verify_access(roleable_roles, controller_instance)
-        roles_permitted?(roleable_roles, controller_instance) && dynamic_rule_followed?(controller_instance)
+      def verify_access(roleable, controller_instance)
+        roles_permitted?(roleable, controller_instance) && dynamic_rule_followed?(controller_instance)
       end
 
-      def roles_permitted?(roleable_roles, controller_instance)
-        return false if Rabarber::Configuration.instance.must_have_roles && roleable_roles.empty?
+      def roles_permitted?(roleable, controller_instance)
+        processed_context = get_context(controller_instance)
 
-        roles.empty? || roles.intersection(roleable_roles.names(context: get_context(controller_instance))).any?
+        return false if Rabarber::Configuration.instance.must_have_roles && roleable.roles(context: processed_context).empty?
+
+        roles.empty? || roles.intersection(roleable.roles(context: processed_context)).any?
       end
 
       def dynamic_rule_followed?(controller_instance)

--- a/lib/rabarber/core/rule.rb
+++ b/lib/rabarber/core/rule.rb
@@ -19,10 +19,11 @@ module Rabarber
 
       def roles_permitted?(roleable, controller_instance)
         processed_context = get_context(controller_instance)
+        roleable_roles = roleable.roles(context: processed_context)
 
-        return false if Rabarber::Configuration.instance.must_have_roles && roleable.roles(context: processed_context).empty?
+        return false if Rabarber::Configuration.instance.must_have_roles && roleable_roles.empty?
 
-        roles.empty? || roles.intersection(roleable.roles(context: processed_context)).any?
+        roles.empty? || roles.intersection(roleable_roles).any?
       end
 
       def dynamic_rule_followed?(controller_instance)

--- a/lib/rabarber/core/rule.rb
+++ b/lib/rabarber/core/rule.rb
@@ -13,34 +13,42 @@ module Rabarber
         @negated_dynamic_rule = negated_dynamic_rule
       end
 
-      def verify_access(roleable_roles, dynamic_rule_receiver)
-        roles_permitted?(roleable_roles) && dynamic_rule_followed?(dynamic_rule_receiver)
+      def verify_access(roleable_roles, controller_instance)
+        roles_permitted?(roleable_roles, controller_instance) && dynamic_rule_followed?(controller_instance)
       end
 
-      def roles_permitted?(roleable_roles)
+      def roles_permitted?(roleable_roles, controller_instance)
         return false if Rabarber::Configuration.instance.must_have_roles && roleable_roles.empty?
 
-        roles.empty? || roles.intersection(roleable_roles.names(context: context)).any?
+        roles.empty? || roles.intersection(roleable_roles.names(context: get_context(controller_instance))).any?
       end
 
-      def dynamic_rule_followed?(dynamic_rule_receiver)
-        !!(execute_dynamic_rule(dynamic_rule_receiver, false) && execute_dynamic_rule(dynamic_rule_receiver, true))
+      def dynamic_rule_followed?(controller_instance)
+        !!(execute_dynamic_rule(controller_instance, false) && execute_dynamic_rule(controller_instance, true))
       end
 
       private
 
-      def execute_dynamic_rule(dynamic_rule_receiver, is_negated)
+      def execute_dynamic_rule(controller_instance, is_negated)
         rule = is_negated ? negated_dynamic_rule : dynamic_rule
 
         return true if rule.nil?
 
-        result = if rule.is_a?(Proc)
-                   dynamic_rule_receiver.instance_exec(&rule)
-                 else
-                   dynamic_rule_receiver.send(rule)
-                 end
+        result = !!if rule.is_a?(Proc)
+                     controller_instance.instance_exec(&rule)
+                   else
+                     controller_instance.send(rule)
+                   end
 
         is_negated ? !result : result
+      end
+
+      def get_context(controller_instance)
+        case context
+        when Proc then Rabarber::Input::Context.new(controller_instance.instance_exec(&context)).process
+        when Symbol then Rabarber::Input::Context.new(controller_instance.send(context)).process
+        else context
+        end
       end
     end
   end

--- a/lib/rabarber/core/rule.rb
+++ b/lib/rabarber/core/rule.rb
@@ -3,11 +3,12 @@
 module Rabarber
   module Core
     class Rule
-      attr_reader :action, :roles, :dynamic_rule, :negated_dynamic_rule
+      attr_reader :action, :roles, :context, :dynamic_rule, :negated_dynamic_rule
 
-      def initialize(action, roles, dynamic_rule, negated_dynamic_rule)
+      def initialize(action, roles, context, dynamic_rule, negated_dynamic_rule)
         @action = action
         @roles = Array(roles)
+        @context = context
         @dynamic_rule = dynamic_rule
         @negated_dynamic_rule = negated_dynamic_rule
       end
@@ -19,7 +20,7 @@ module Rabarber
       def roles_permitted?(roleable_roles)
         return false if Rabarber::Configuration.instance.must_have_roles && roleable_roles.empty?
 
-        roles.empty? || roles.intersection(roleable_roles).any?
+        roles.empty? || roles.intersection(roleable_roles.names(context: context)).any?
       end
 
       def dynamic_rule_followed?(dynamic_rule_receiver)

--- a/lib/rabarber/helpers/helpers.rb
+++ b/lib/rabarber/helpers/helpers.rb
@@ -4,14 +4,14 @@ module Rabarber
   module Helpers
     include Rabarber::Core::Roleable
 
-    def visible_to(*roles, &block)
-      return unless roleable_roles.intersection(Rabarber::Input::Roles.new(roles).process).any?
+    def visible_to(*roles, context: nil, &block)
+      return unless roleable_roles.names(context: Rabarber::Input::Context.new(context).process).intersection(Rabarber::Input::Roles.new(roles).process).any?
 
       capture(&block)
     end
 
-    def hidden_from(*roles, &block)
-      return if roleable_roles.intersection(Rabarber::Input::Roles.new(roles).process).any?
+    def hidden_from(*roles, context: nil, &block)
+      return if roleable_roles.names(context: Rabarber::Input::Context.new(context).process).intersection(Rabarber::Input::Roles.new(roles).process).any?
 
       capture(&block)
     end

--- a/lib/rabarber/helpers/helpers.rb
+++ b/lib/rabarber/helpers/helpers.rb
@@ -5,13 +5,13 @@ module Rabarber
     include Rabarber::Core::Roleable
 
     def visible_to(*roles, context: nil, &block)
-      return unless roleable_roles.names(context: Rabarber::Input::Context.new(context).process).intersection(Rabarber::Input::Roles.new(roles).process).any?
+      return if roleable_roles(context: Rabarber::Input::Context.new(context).process).intersection(Rabarber::Input::Roles.new(roles).process).none?
 
       capture(&block)
     end
 
     def hidden_from(*roles, context: nil, &block)
-      return if roleable_roles.names(context: Rabarber::Input::Context.new(context).process).intersection(Rabarber::Input::Roles.new(roles).process).any?
+      return if roleable_roles(context: Rabarber::Input::Context.new(context).process).intersection(Rabarber::Input::Roles.new(roles).process).any?
 
       capture(&block)
     end

--- a/lib/rabarber/input/action.rb
+++ b/lib/rabarber/input/action.rb
@@ -11,10 +11,8 @@ module Rabarber
 
       def processed_value
         case value
-        when String, Symbol
-          value.to_sym
-        when nil
-          value
+        when String, Symbol then value.to_sym
+        when nil then value
         end
       end
 

--- a/lib/rabarber/input/authorization_context.rb
+++ b/lib/rabarber/input/authorization_context.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Rabarber
+  module Input
+    class AuthorizationContext < Rabarber::Input::Base
+      def valid?
+        Rabarber::Input::Context.new(value).valid? || Rabarber::Input::DynamicRule.new(value).valid?
+      end
+
+      private
+
+      def processed_value
+        case value
+        when Symbol, String then value.to_sym
+        when Proc then value
+        else Rabarber::Input::Context.new(value).process
+        end
+      end
+
+      def default_error_message
+        "Context must be a Class, an instance of ActiveRecord::Base, a Symbol, a String, or a Proc"
+      end
+    end
+  end
+end

--- a/lib/rabarber/input/authorization_context.rb
+++ b/lib/rabarber/input/authorization_context.rb
@@ -18,7 +18,7 @@ module Rabarber
       end
 
       def default_error_message
-        "Context must be a Class, an instance of ActiveRecord::Base, a Symbol, a String, or a Proc"
+        "Context must be a Class, an instance of ActiveRecord model, a Symbol, a String, or a Proc"
       end
     end
   end

--- a/lib/rabarber/input/context.rb
+++ b/lib/rabarber/input/context.rb
@@ -4,7 +4,7 @@ module Rabarber
   module Input
     class Context < Rabarber::Input::Base
       def valid?
-        value.nil? || value.is_a?(Class) || value.is_a?(ActiveRecord::Base)
+        value.nil? || value.is_a?(Class) || value.is_a?(ActiveRecord::Base) || already_processed?
       end
 
       private
@@ -13,12 +13,22 @@ module Rabarber
         case value
         when nil then { context_type: nil, context_id: nil }
         when Class then { context_type: value.to_s, context_id: nil }
-        when ActiveRecord::Base then { context_type: value.class.to_s, context_id: value.public_send(value.class.primary_key) }
+        when ActiveRecord::Base then {
+          context_type: value.class.to_s, context_id: value.public_send(value.class.primary_key)
+        }
+        else value
         end
       end
 
       def default_error_message
         "Context must be a Class or an instance of ActiveRecord::Base"
+      end
+
+      def already_processed?
+        case value
+        in { context_type: NilClass | String, context_id: NilClass | String | Integer } then true
+        else false
+        end
       end
     end
   end

--- a/lib/rabarber/input/context.rb
+++ b/lib/rabarber/input/context.rb
@@ -4,7 +4,7 @@ module Rabarber
   module Input
     class Context < Rabarber::Input::Base
       def valid?
-        value.nil? || value.is_a?(Class) || value.is_a?(ActiveRecord::Base) || already_processed?
+        value.nil? || value.is_a?(Class) || value.is_a?(ActiveRecord::Base) && value.persisted? || already_processed?
       end
 
       private
@@ -19,7 +19,7 @@ module Rabarber
       end
 
       def default_error_message
-        "Context must be a Class or an instance of ActiveRecord::Base"
+        "Context must be a Class or an instance of ActiveRecord model"
       end
 
       def already_processed?

--- a/lib/rabarber/input/context.rb
+++ b/lib/rabarber/input/context.rb
@@ -12,8 +12,8 @@ module Rabarber
       def processed_value
         case value
         when nil then { context_type: nil, context_id: nil }
-        when Class then { context_type: value, context_id: nil }
-        when ActiveRecord::Base then { context_type: value.class, context_id: value.public_send(value.class.primary_key) }
+        when Class then { context_type: value.to_s, context_id: nil }
+        when ActiveRecord::Base then { context_type: value.class.to_s, context_id: value.public_send(value.class.primary_key) }
         end
       end
 

--- a/lib/rabarber/input/context.rb
+++ b/lib/rabarber/input/context.rb
@@ -13,9 +13,7 @@ module Rabarber
         case value
         when nil then { context_type: nil, context_id: nil }
         when Class then { context_type: value.to_s, context_id: nil }
-        when ActiveRecord::Base then {
-          context_type: value.class.to_s, context_id: value.public_send(value.class.primary_key)
-        }
+        when ActiveRecord::Base then { context_type: value.class.to_s, context_id: value.public_send(value.class.primary_key) }
         else value
         end
       end

--- a/lib/rabarber/input/context.rb
+++ b/lib/rabarber/input/context.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Rabarber
+  module Input
+    class Context < Rabarber::Input::Base
+      def valid?
+        value.nil? || value.is_a?(Class) || value.is_a?(ActiveRecord::Base)
+      end
+
+      private
+
+      def processed_value
+        case value
+        when nil then { context_type: nil, context_id: nil }
+        when Class then { context_type: value, context_id: nil }
+        when ActiveRecord::Base then { context_type: value.class, context_id: value.public_send(value.class.primary_key) }
+        end
+      end
+
+      def default_error_message
+        "Context must be a Class or an instance of ActiveRecord::Base"
+      end
+    end
+  end
+end

--- a/lib/rabarber/input/dynamic_rule.rb
+++ b/lib/rabarber/input/dynamic_rule.rb
@@ -11,10 +11,8 @@ module Rabarber
 
       def processed_value
         case value
-        when String, Symbol
-          value.to_sym
-        when Proc, nil
-          value
+        when String, Symbol then value.to_sym
+        when Proc, nil then value
         end
       end
 

--- a/lib/rabarber/models/concerns/has_roles.rb
+++ b/lib/rabarber/models/concerns/has_roles.rb
@@ -14,43 +14,62 @@ module Rabarber
                                                join_table: "rabarber_roles_roleables"
     end
 
-    def roles
-      Rabarber::Core::Cache.fetch(roleable_id) { rabarber_roles.names }
+    def roles(context: nil)
+      processed_context = process_context(context)
+      Rabarber::Core::Cache.fetch(roleable_id, context: processed_context) { rabarber_roles.names(context: processed_context) }
     end
 
-    def has_role?(*role_names)
-      roles.intersection(process_role_names(role_names)).any?
+    def has_role?(*role_names, context: nil)
+      processed_context = process_context(context)
+      roles(context: processed_context).intersection(process_role_names(role_names)).any?
     end
 
-    def assign_roles(*role_names, create_new: true)
+    def assign_roles(*role_names, context: nil, create_new: true)
       processed_role_names = process_role_names(role_names)
+      processed_context = process_context(context)
 
-      create_new_roles(processed_role_names) if create_new
+      create_new_roles(processed_role_names, context: processed_context) if create_new
 
-      roles_to_assign = Rabarber::Role.where(name: processed_role_names - rabarber_roles.names)
+      roles_to_assign = Rabarber::Role.where(
+        name: (processed_role_names - rabarber_roles.names(context: processed_context)), **processed_context
+      )
 
       if roles_to_assign.any?
-        delete_roleable_cache
+        delete_roleable_cache(context: processed_context)
         rabarber_roles << roles_to_assign
 
-        Rabarber::Audit::Events::RolesAssigned.trigger(self, roles_to_assign: roles_to_assign.names, current_roles: roles)
+        Rabarber::Audit::Events::RolesAssigned.trigger(
+          self,
+          roles_to_assign: roles_to_assign.names(context: processed_context),
+          current_roles: roles(context: processed_context),
+          context: processed_context
+        )
       end
 
-      roles
+      roles(context: processed_context)
     end
 
-    def revoke_roles(*role_names)
+    def revoke_roles(*role_names, context: nil)
       processed_role_names = process_role_names(role_names)
-      roles_to_revoke = Rabarber::Role.where(name: processed_role_names.intersection(roles))
+      processed_context = process_context(context)
+
+      roles_to_revoke = Rabarber::Role.where(
+        name: processed_role_names.intersection(roles(context: processed_context)), **processed_context
+      )
 
       if roles_to_revoke.any?
-        delete_roleable_cache
+        delete_roleable_cache(context: processed_context)
         self.rabarber_roles -= roles_to_revoke
 
-        Rabarber::Audit::Events::RolesRevoked.trigger(self, roles_to_revoke: roles_to_revoke.names, current_roles: roles)
+        Rabarber::Audit::Events::RolesRevoked.trigger(
+          self,
+          roles_to_revoke: roles_to_revoke.names(context: processed_context),
+          current_roles: roles(context: processed_context),
+          context: processed_context
+        )
       end
 
-      roles
+      roles(context: processed_context)
     end
 
     def roleable_class
@@ -60,17 +79,21 @@ module Rabarber
 
     private
 
-    def create_new_roles(role_names)
-      new_roles = role_names - Rabarber::Role.names
-      new_roles.each { |role_name| Rabarber::Role.create!(name: role_name) }
+    def create_new_roles(role_names, context:)
+      new_roles = role_names - Rabarber::Role.names(context: context)
+      new_roles.each { |role_name| Rabarber::Role.create!(name: role_name, **context) }
     end
 
     def process_role_names(role_names)
       Rabarber::Input::Roles.new(role_names).process
     end
 
-    def delete_roleable_cache
-      Rabarber::Core::Cache.delete(roleable_id)
+    def process_context(context)
+      Rabarber::Input::Context.new(context).process
+    end
+
+    def delete_roleable_cache(context:)
+      Rabarber::Core::Cache.delete(roleable_id, context: context)
     end
 
     def roleable_id

--- a/lib/rabarber/models/role.rb
+++ b/lib/rabarber/models/role.rb
@@ -16,45 +16,48 @@ module Rabarber
         where(Rabarber::Input::Context.new(context).process).pluck(:name).map(&:to_sym)
       end
 
-      def add(name)
+      def add(name, context: nil)
         name = process_role_name(name)
+        processed_context = process_context(context)
 
-        return false if exists?(name: name)
+        return false if exists?(name: name, **processed_context)
 
-        !!create!(name: name)
+        !!create!(name: name, **processed_context)
       end
 
-      def rename(old_name, new_name, force: false)
-        role = find_by(name: process_role_name(old_name))
+      def rename(old_name, new_name, context: nil, force: false)
+        processed_context = process_context(context)
+        role = find_by(name: process_role_name(old_name), **processed_context)
         name = process_role_name(new_name)
 
-        return false if !role || exists?(name: name) || assigned_to_roleables(role).any? && !force
+        return false if !role || exists?(name: name, **processed_context) || assigned_to_roleables(role).any? && !force
 
-        delete_roleables_cache(role)
+        delete_roleables_cache(role, context: processed_context)
 
         role.update!(name: name)
       end
 
-      def remove(name, force: false)
-        role = find_by(name: process_role_name(name))
+      def remove(name, context: nil, force: false)
+        processed_context = process_context(context)
+        role = find_by(name: process_role_name(name), **processed_context)
 
         return false if !role || assigned_to_roleables(role).any? && !force
 
-        delete_roleables_cache(role)
+        delete_roleables_cache(role, context: processed_context)
 
         !!role.destroy!
       end
 
-      def assignees(name)
+      def assignees(name, context: nil)
         Rabarber::HasRoles.roleable_class.joins(:rabarber_roles).where(
-          rabarber_roles: { name: Rabarber::Input::Role.new(name).process }
+          rabarber_roles: { name: Rabarber::Input::Role.new(name).process, **process_context(context) }
         )
       end
 
       private
 
-      def delete_roleables_cache(role)
-        Rabarber::Core::Cache.delete(*assigned_to_roleables(role))
+      def delete_roleables_cache(role, context:)
+        Rabarber::Core::Cache.delete(*assigned_to_roleables(role), context: context)
       end
 
       def assigned_to_roleables(role)
@@ -67,6 +70,10 @@ module Rabarber
 
       def process_role_name(name)
         Rabarber::Input::Role.new(name).process
+      end
+
+      def process_context(context)
+        Rabarber::Input::Context.new(context).process
       end
     end
   end

--- a/lib/rabarber/models/role.rb
+++ b/lib/rabarber/models/role.rb
@@ -12,8 +12,8 @@ module Rabarber
     has_and_belongs_to_many :roleables, join_table: "rabarber_roles_roleables"
 
     class << self
-      def names
-        pluck(:name).map(&:to_sym)
+      def names(context: nil)
+        where(Rabarber::Input::Context.new(context).process).pluck(:name).map(&:to_sym)
       end
 
       def add(name)

--- a/lib/rabarber/models/role.rb
+++ b/lib/rabarber/models/role.rb
@@ -4,7 +4,10 @@ module Rabarber
   class Role < ActiveRecord::Base
     self.table_name = "rabarber_roles"
 
-    validates :name, presence: true, uniqueness: true, format: { with: Rabarber::Input::Role::REGEX }, strict: true
+    validates :name, presence: true,
+                     uniqueness: { scope: [:context_type, :context_id] },
+                     format: { with: Rabarber::Input::Role::REGEX },
+                     strict: true
 
     has_and_belongs_to_many :roleables, join_table: "rabarber_roles_roleables"
 

--- a/lib/rabarber/version.rb
+++ b/lib/rabarber/version.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 module Rabarber
+  # TODO: bump
   VERSION = "2.1.0"
 end

--- a/lib/rabarber/version.rb
+++ b/lib/rabarber/version.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
 module Rabarber
-  # TODO: bump
-  VERSION = "2.1.0"
+  VERSION = "3.0.0"
 end

--- a/spec/generators/roles_generator_spec.rb
+++ b/spec/generators/roles_generator_spec.rb
@@ -31,9 +31,12 @@ RSpec.describe Rabarber::RolesGenerator do
         class CreateRabarberRoles < ActiveRecord::Migration[6.2]
           def change
             create_table :rabarber_roles do |t|
-              t.string :name, null: false, index: { unique: true }
+              t.string :name, null: false
+              t.belongs_to :context, polymorphic: true, index: true
               t.timestamps
             end
+
+            add_index :rabarber_roles, [:name, :context_type, :context_id], unique: true
 
             create_table :rabarber_roles_roleables, id: false do |t|
               t.belongs_to :role, null: false, index: true, foreign_key: { to_table: :rabarber_roles }
@@ -61,9 +64,12 @@ RSpec.describe Rabarber::RolesGenerator do
         class CreateRabarberRoles < ActiveRecord::Migration[6.2]
           def change
             create_table :rabarber_roles, id: :uuid do |t|
-              t.string :name, null: false, index: { unique: true }
+              t.string :name, null: false
+              t.belongs_to :context, polymorphic: true, index: true, type: :uuid
               t.timestamps
             end
+
+            add_index :rabarber_roles, [:name, :context_type, :context_id], unique: true
 
             create_table :rabarber_roles_roleables, id: false do |t|
               t.belongs_to :role, null: false, index: true, foreign_key: { to_table: :rabarber_roles }, type: :uuid

--- a/spec/rabarber/audit/events/roles_assigned_spec.rb
+++ b/spec/rabarber/audit/events/roles_assigned_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Rabarber::Audit::Events::RolesAssigned do
     let(:roleable) { User.create }
 
     it "logs the role assignment" do
-      expect(Rabarber::Audit::Logger).to receive(:log).with(:info, "[Role Assignment] User##{roleable.id} | context: 'Global', assigned roles: #{roles_to_assign}, current roles: #{current_roles}").and_call_original
+      expect(Rabarber::Audit::Logger).to receive(:log).with(:info, "[Role Assignment] User##{roleable.id} | context: Global | assigned: #{roles_to_assign} | current: #{current_roles}").and_call_original
       subject
     end
   end

--- a/spec/rabarber/audit/events/roles_assigned_spec.rb
+++ b/spec/rabarber/audit/events/roles_assigned_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Rabarber::Audit::Events::RolesAssigned do
-  subject { described_class.trigger(roleable, roles_to_assign: roles_to_assign, current_roles: current_roles) }
+  subject { described_class.trigger(roleable, context: context, roles_to_assign: roles_to_assign, current_roles: current_roles) }
 
+  let(:context) { { context_type: nil, context_id: nil } }
   let(:roles_to_assign) { [:admin, :manager] }
   let(:current_roles) { [:admin, :manager, :accountant] }
 
@@ -10,7 +11,7 @@ RSpec.describe Rabarber::Audit::Events::RolesAssigned do
     let(:roleable) { User.create }
 
     it "logs the role assignment" do
-      expect(Rabarber::Audit::Logger).to receive(:log).with(:info, "[Role Assignment] User with id: '#{roleable.id}' has been assigned the following roles: #{roles_to_assign}, current roles: #{current_roles}").and_call_original
+      expect(Rabarber::Audit::Logger).to receive(:log).with(:info, "[Role Assignment] User##{roleable.id} | context: 'Global', assigned roles: #{roles_to_assign}, current roles: #{current_roles}").and_call_original
       subject
     end
   end

--- a/spec/rabarber/audit/events/roles_revoked_spec.rb
+++ b/spec/rabarber/audit/events/roles_revoked_spec.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe Rabarber::Audit::Events::RolesRevoked do
-  subject { described_class.trigger(roleable, roles_to_revoke: roles_to_revoke, current_roles: current_roles) }
+  subject { described_class.trigger(roleable, context: context, roles_to_revoke: roles_to_revoke, current_roles: current_roles) }
 
+  let(:project) { Project.create! }
+  let(:context) { { context_type: "Project", context_id: project.id } }
   let(:roles_to_revoke) { [:admin, :manager] }
   let(:current_roles) { [:accountant] }
 
@@ -10,7 +12,7 @@ RSpec.describe Rabarber::Audit::Events::RolesRevoked do
     let(:roleable) { User.create }
 
     it "logs the role revocation" do
-      expect(Rabarber::Audit::Logger).to receive(:log).with(:info, "[Role Revocation] User with id: '#{roleable.id}' has been revoked from the following roles: #{roles_to_revoke}, current roles: #{current_roles}").and_call_original
+      expect(Rabarber::Audit::Logger).to receive(:log).with(:info, "[Role Revocation] User##{roleable.id} | context: 'Project##{project.id}', revoked roles: #{roles_to_revoke}, current roles: #{current_roles}").and_call_original
       subject
     end
   end

--- a/spec/rabarber/audit/events/roles_revoked_spec.rb
+++ b/spec/rabarber/audit/events/roles_revoked_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Rabarber::Audit::Events::RolesRevoked do
     let(:roleable) { User.create }
 
     it "logs the role revocation" do
-      expect(Rabarber::Audit::Logger).to receive(:log).with(:info, "[Role Revocation] User##{roleable.id} | context: 'Project##{project.id}', revoked roles: #{roles_to_revoke}, current roles: #{current_roles}").and_call_original
+      expect(Rabarber::Audit::Logger).to receive(:log).with(:info, "[Role Revocation] User##{roleable.id} | context: Project##{project.id} | revoked: #{roles_to_revoke} | current: #{current_roles}").and_call_original
       subject
     end
   end

--- a/spec/rabarber/audit/events/unauthorized_attempt_spec.rb
+++ b/spec/rabarber/audit/events/unauthorized_attempt_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Rabarber::Audit::Events::UnauthorizedAttempt do
     before { roleable.assign_roles(:admin) }
 
     it "logs the unauthorized attempt" do
-      expect(Rabarber::Audit::Logger).to receive(:log).with(:warn, "[Unauthorized Attempt] User with id: '#{roleable.id}', roles: [:admin] attempted to access '#{path}'").and_call_original
+      expect(Rabarber::Audit::Logger).to receive(:log).with(:warn, "[Unauthorized Attempt] User##{roleable.id} | path: '#{path}'").and_call_original
       subject
     end
   end
@@ -20,7 +20,7 @@ RSpec.describe Rabarber::Audit::Events::UnauthorizedAttempt do
     let(:roleable) { nil }
 
     it "logs the unauthorized attempt" do
-      expect(Rabarber::Audit::Logger).to receive(:log).with(:warn, "[Unauthorized Attempt] Unauthenticated user attempted to access '#{path}'").and_call_original
+      expect(Rabarber::Audit::Logger).to receive(:log).with(:warn, "[Unauthorized Attempt] Unauthenticated user | path: '#{path}'").and_call_original
       subject
     end
   end

--- a/spec/rabarber/audit/events/unauthorized_attempt_spec.rb
+++ b/spec/rabarber/audit/events/unauthorized_attempt_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Rabarber::Audit::Events::UnauthorizedAttempt do
   end
 
   context "when roleable is nil" do
-    let(:roleable) { nil }
+    let(:roleable) { Rabarber::Core::NullRoleable.new }
 
     it "logs the unauthorized attempt" do
       expect(Rabarber::Audit::Logger).to receive(:log).with(:warn, "[Unauthorized Attempt] Unauthenticated user | request: DELETE '/admin'").and_call_original

--- a/spec/rabarber/audit/events/unauthorized_attempt_spec.rb
+++ b/spec/rabarber/audit/events/unauthorized_attempt_spec.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Rabarber::Audit::Events::UnauthorizedAttempt do
-  subject { described_class.trigger(roleable, path: path) }
-
-  let(:path) { "/admin" }
+  subject { described_class.trigger(roleable, path: "/admin", request_method: "DELETE") }
 
   context "when roleable is not nil" do
     let(:roleable) { User.create }
@@ -11,7 +9,7 @@ RSpec.describe Rabarber::Audit::Events::UnauthorizedAttempt do
     before { roleable.assign_roles(:admin) }
 
     it "logs the unauthorized attempt" do
-      expect(Rabarber::Audit::Logger).to receive(:log).with(:warn, "[Unauthorized Attempt] User##{roleable.id} | path: '#{path}'").and_call_original
+      expect(Rabarber::Audit::Logger).to receive(:log).with(:warn, "[Unauthorized Attempt] User##{roleable.id} | request: DELETE '/admin'").and_call_original
       subject
     end
   end
@@ -20,7 +18,7 @@ RSpec.describe Rabarber::Audit::Events::UnauthorizedAttempt do
     let(:roleable) { nil }
 
     it "logs the unauthorized attempt" do
-      expect(Rabarber::Audit::Logger).to receive(:log).with(:warn, "[Unauthorized Attempt] Unauthenticated user | path: '#{path}'").and_call_original
+      expect(Rabarber::Audit::Logger).to receive(:log).with(:warn, "[Unauthorized Attempt] Unauthenticated user | request: DELETE '/admin'").and_call_original
       subject
     end
   end

--- a/spec/rabarber/audit/events/unauthorized_attempt_spec.rb
+++ b/spec/rabarber/audit/events/unauthorized_attempt_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Rabarber::Audit::Events::UnauthorizedAttempt do
     before { roleable.assign_roles(:admin) }
 
     it "logs the unauthorized attempt" do
-      expect(Rabarber::Audit::Logger).to receive(:log).with(:warn, "[Unauthorized Attempt] User##{roleable.id} | request: DELETE '/admin'").and_call_original
+      expect(Rabarber::Audit::Logger).to receive(:log).with(:warn, "[Unauthorized Attempt] User##{roleable.id} | request: DELETE /admin").and_call_original
       subject
     end
   end
@@ -18,7 +18,7 @@ RSpec.describe Rabarber::Audit::Events::UnauthorizedAttempt do
     let(:roleable) { Rabarber::Core::NullRoleable.new }
 
     it "logs the unauthorized attempt" do
-      expect(Rabarber::Audit::Logger).to receive(:log).with(:warn, "[Unauthorized Attempt] Unauthenticated user | request: DELETE '/admin'").and_call_original
+      expect(Rabarber::Audit::Logger).to receive(:log).with(:warn, "[Unauthorized Attempt] Unauthenticated user | request: DELETE /admin").and_call_original
       subject
     end
   end

--- a/spec/rabarber/controllers/concerns/authorization_spec.rb
+++ b/spec/rabarber/controllers/concerns/authorization_spec.rb
@@ -34,6 +34,17 @@ RSpec.describe Rabarber::Authorization do
       end
     end
 
+    context "when context is invalid" do
+      let(:args) { { context: 1 } }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(
+          Rabarber::InvalidArgumentError,
+          "Context must be a Class, an instance of ActiveRecord::Base, a Symbol, a String, or a Proc"
+        )
+      end
+    end
+
     context "when dynamic rule is invalid" do
       let(:args) { { if: 1 } }
 
@@ -57,7 +68,7 @@ RSpec.describe Rabarber::Authorization do
     end
 
     context "when everything is valid" do
-      let(:args) { { action: :index, roles: :admin, if: -> { true }, unless: -> { false } } }
+      let(:args) { { action: :index, roles: :admin, context: nil, if: -> { true }, unless: -> { false } } }
 
       it "adds the permission" do
         expect(Rabarber::Core::Permissions).to receive(:add)
@@ -75,6 +86,13 @@ RSpec.describe Rabarber::Authorization do
       it "uses Input::Roles to process the given roles" do
         input_processor = instance_double(Rabarber::Input::Roles, process: [:admin])
         allow(Rabarber::Input::Roles).to receive(:new).with(:admin).and_return(input_processor)
+        expect(input_processor).to receive(:process).with(no_args)
+        subject
+      end
+
+      it "uses Input::AuthorizationContext to process the given context" do
+        input_processor = instance_double(Rabarber::Input::AuthorizationContext, process: nil)
+        allow(Rabarber::Input::AuthorizationContext).to receive(:new).with(nil).and_return(input_processor)
         expect(input_processor).to receive(:process).with(no_args)
         subject
       end
@@ -136,6 +154,16 @@ RSpec.describe Rabarber::Authorization do
       it "adds the permission" do
         expect(Rabarber::Core::Permissions).to receive(:add)
           .with(DummyAuthController, nil, [], { context_id: nil, context_type: nil }, nil, nil).and_call_original
+        subject
+      end
+    end
+
+    context "when context is specified" do
+      let(:args) { { context: Project } }
+
+      it "adds the permission" do
+        expect(Rabarber::Core::Permissions).to receive(:add)
+          .with(DummyAuthController, nil, [], { context_id: nil, context_type: "Project" }, nil, nil).and_call_original
         subject
       end
     end
@@ -520,6 +548,103 @@ RSpec.describe Rabarber::Authorization do
 
       it_behaves_like "it does not allow access when user must have roles", post: :no_skip
       it_behaves_like "it checks permissions integrity", post: :no_skip
+    end
+  end
+
+  describe ContextController, type: :controller do
+    before { allow(controller).to receive(:current_user).and_return(user) }
+
+    describe "when context is global" do
+      context "when the user's role allows access" do
+        before { user.assign_roles(:admin) }
+
+        it_behaves_like "it allows access", get: :global_ctx
+      end
+
+      context "when the user's role does not allow access" do
+        before { user.assign_roles(:admin, context: Project) }
+
+        it_behaves_like "it does not allow access", get: :global_ctx
+      end
+
+      it_behaves_like "it does not allow access when user must have roles", get: :global_ctx
+      it_behaves_like "it checks permissions integrity", get: :global_ctx
+    end
+
+    describe "when context is a class" do
+      context "when the user's role allows access" do
+        before { user.assign_roles(:admin, context: Project) }
+
+        it_behaves_like "it allows access", post: :class_ctx
+      end
+
+      context "when the user's role does not allow access" do
+        before { user.assign_roles(:admin) }
+
+        it_behaves_like "it does not allow access", post: :class_ctx
+      end
+
+      it_behaves_like "it does not allow access when user must have roles", post: :class_ctx
+      it_behaves_like "it checks permissions integrity", post: :class_ctx
+    end
+
+    describe "when context is an instance" do
+      context "when the user's role allows access" do
+        before do
+          project = Project.create!
+          allow(Project).to receive(:create!).and_return(project)
+          user.assign_roles(:admin, context: project)
+        end
+
+        it_behaves_like "it allows access", put: :instance_ctx
+      end
+
+      context "when the user's role does not allow access" do
+        before { user.assign_roles(:admin, context: Project) }
+
+        it_behaves_like "it does not allow access", put: :instance_ctx
+      end
+
+      it_behaves_like "it does not allow access when user must have roles", put: :instance_ctx
+      it_behaves_like "it checks permissions integrity", put: :instance_ctx
+    end
+
+    context "when context is a symbol" do
+      context "when the user's role allows access" do
+        before do
+          project = Project.create!
+          allow(Project).to receive(:create!).and_return(project)
+          user.assign_roles(:admin, context: project)
+        end
+
+        it_behaves_like "it allows access", patch: :symbol_ctx
+      end
+
+      context "when the user's role does not allow access" do
+        before { user.assign_roles(:admin) }
+
+        it_behaves_like "it does not allow access", patch: :symbol_ctx
+      end
+
+      it_behaves_like "it does not allow access when user must have roles", patch: :symbol_ctx
+      it_behaves_like "it checks permissions integrity", patch: :symbol_ctx
+    end
+
+    context "when context is a proc" do
+      context "when the user's role allows access" do
+        before { user.assign_roles(:admin, context: Project) }
+
+        it_behaves_like "it allows access", delete: :proc_ctx
+      end
+
+      context "when the user's role does not allow access" do
+        before { user.assign_roles(:admin, context: Project.create!) }
+
+        it_behaves_like "it does not allow access", delete: :proc_ctx
+      end
+
+      it_behaves_like "it does not allow access when user must have roles", delete: :proc_ctx
+      it_behaves_like "it checks permissions integrity", delete: :proc_ctx
     end
   end
 end

--- a/spec/rabarber/controllers/concerns/authorization_spec.rb
+++ b/spec/rabarber/controllers/concerns/authorization_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Rabarber::Authorization do
       it "raises an error" do
         expect { subject }.to raise_error(
           Rabarber::InvalidArgumentError,
-          "Context must be a Class, an instance of ActiveRecord::Base, a Symbol, a String, or a Proc"
+          "Context must be a Class, an instance of ActiveRecord model, a Symbol, a String, or a Proc"
         )
       end
     end

--- a/spec/rabarber/controllers/concerns/authorization_spec.rb
+++ b/spec/rabarber/controllers/concerns/authorization_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Rabarber::Authorization do
 
       it "adds the permission" do
         expect(Rabarber::Core::Permissions).to receive(:add)
-          .with(DummyAuthController, :index, [:admin], args[:if], args[:unless]).and_call_original
+          .with(DummyAuthController, :index, [:admin], { context_id: nil, context_type: nil }, args[:if], args[:unless]).and_call_original
         subject
       end
 
@@ -95,7 +95,7 @@ RSpec.describe Rabarber::Authorization do
 
       it "adds the permission" do
         expect(Rabarber::Core::Permissions).to receive(:add)
-          .with(DummyAuthController, :foo, [:bar], args[:if], nil).and_call_original
+          .with(DummyAuthController, :foo, [:bar], { context_id: nil, context_type: nil }, args[:if], nil).and_call_original
         subject
       end
     end
@@ -105,7 +105,7 @@ RSpec.describe Rabarber::Authorization do
 
       it "adds the permission" do
         expect(Rabarber::Core::Permissions).to receive(:add)
-          .with(DummyAuthController, :foo, [:bar], nil, args[:unless]).and_call_original
+          .with(DummyAuthController, :foo, [:bar], { context_id: nil, context_type: nil }, nil, args[:unless]).and_call_original
         subject
       end
     end
@@ -115,7 +115,7 @@ RSpec.describe Rabarber::Authorization do
 
       it "adds the permission" do
         expect(Rabarber::Core::Permissions).to receive(:add)
-          .with(DummyAuthController, :foo, [:bar], nil, nil).and_call_original
+          .with(DummyAuthController, :foo, [:bar], { context_id: nil, context_type: nil }, nil, nil).and_call_original
         subject
       end
     end
@@ -125,7 +125,7 @@ RSpec.describe Rabarber::Authorization do
 
       it "adds the permission" do
         expect(Rabarber::Core::Permissions).to receive(:add)
-          .with(DummyAuthController, :foo, [:bar], args[:if], args[:unless]).and_call_original
+          .with(DummyAuthController, :foo, [:bar], { context_id: nil, context_type: nil }, args[:if], args[:unless]).and_call_original
         subject
       end
     end
@@ -135,7 +135,7 @@ RSpec.describe Rabarber::Authorization do
 
       it "adds the permission" do
         expect(Rabarber::Core::Permissions).to receive(:add)
-          .with(DummyAuthController, nil, [], nil, nil).and_call_original
+          .with(DummyAuthController, nil, [], { context_id: nil, context_type: nil }, nil, nil).and_call_original
         subject
       end
     end
@@ -173,7 +173,7 @@ RSpec.describe Rabarber::Authorization do
       allow(Rabarber::Audit::Events::UnauthorizedAttempt).to receive(:trigger).and_call_original
       send(hash.keys.first, hash.values.first, params: hash[:params])
       expect(Rabarber::Audit::Events::UnauthorizedAttempt)
-        .to have_received(:trigger).with(controller.current_user, path: request.path)
+        .to have_received(:trigger).with(controller.current_user.presence || an_instance_of(Rabarber::Core::NullRoleable), path: request.path, request_method: hash.keys.first.to_s.upcase)
     end
   end
 

--- a/spec/rabarber/core/access_spec.rb
+++ b/spec/rabarber/core/access_spec.rb
@@ -6,16 +6,15 @@ RSpec.describe Rabarber::Core::Access do
   before { permissions.extend(described_class) }
 
   describe ".access_granted?" do
-    subject { permissions.access_granted?([:admin, :client], DummyController, :index, controller_instance) }
+    subject { permissions.access_granted?(user, :index, controller_instance) }
 
+    let(:user) { User.create! }
     let(:controller_instance) { double }
 
     context "if controller is accessible" do
       before do
-        allow(permissions).to receive(:controller_accessible?)
-          .with([:admin, :client], DummyController, controller_instance).and_return(true)
-        allow(permissions).to receive(:action_accessible?)
-          .with([:admin, :client], DummyController, :index, controller_instance).and_return(false)
+        allow(permissions).to receive(:controller_accessible?).with(user, controller_instance).and_return(true)
+        allow(permissions).to receive(:action_accessible?).with(user, :index, controller_instance).and_return(false)
       end
 
       it "returns true" do
@@ -25,10 +24,8 @@ RSpec.describe Rabarber::Core::Access do
 
     context "if action is accessible" do
       before do
-        allow(permissions).to receive(:controller_accessible?)
-          .with([:admin, :client], DummyController, controller_instance).and_return(false)
-        allow(permissions).to receive(:action_accessible?)
-          .with([:admin, :client], DummyController, :index, controller_instance).and_return(true)
+        allow(permissions).to receive(:controller_accessible?).with(user, controller_instance).and_return(false)
+        allow(permissions).to receive(:action_accessible?).with(user, :index, controller_instance).and_return(true)
       end
 
       it "returns true" do
@@ -38,10 +35,8 @@ RSpec.describe Rabarber::Core::Access do
 
     context "if controller and action are not accessible" do
       before do
-        allow(permissions).to receive(:controller_accessible?)
-          .with([:admin, :client], DummyController, controller_instance).and_return(false)
-        allow(permissions).to receive(:action_accessible?)
-          .with([:admin, :client], DummyController, :index, controller_instance).and_return(false)
+        allow(permissions).to receive(:controller_accessible?).with(user, controller_instance).and_return(false)
+        allow(permissions).to receive(:action_accessible?).with(user, :index, controller_instance).and_return(false)
       end
 
       it "returns false" do
@@ -51,11 +46,12 @@ RSpec.describe Rabarber::Core::Access do
   end
 
   describe ".controller_accessible?" do
-    subject { permissions.controller_accessible?([:admin], controller, controller_instance) }
+    subject { permissions.controller_accessible?(user, controller_instance) }
 
-    let(:controller_instance) { double }
+    let(:user) { User.create! }
+    let(:controller_instance) { controller.new }
 
-    before { permissions.add(DummyParentController, nil, [:admin], nil, nil) }
+    before { permissions.add(DummyParentController, nil, [:admin], nil, nil, nil) }
 
     context "if controller is in permissions" do
       let(:controller) { DummyParentController }
@@ -63,7 +59,7 @@ RSpec.describe Rabarber::Core::Access do
       context "if role has access to the controller" do
         before do
           allow(permissions.controller_rules[controller]).to receive(:verify_access)
-            .with([:admin], controller_instance).and_return(true)
+            .with(user, controller_instance).and_return(true)
         end
 
         it "returns true" do
@@ -74,7 +70,7 @@ RSpec.describe Rabarber::Core::Access do
       context "if role doesn't have access to the controller" do
         before do
           allow(permissions.controller_rules[controller]).to receive(:verify_access)
-            .with([:admin], controller_instance).and_return(false)
+            .with(user, controller_instance).and_return(false)
         end
 
         it "returns false" do
@@ -89,7 +85,7 @@ RSpec.describe Rabarber::Core::Access do
       context "if role has access to the controller's parent" do
         before do
           allow(permissions.controller_rules[DummyParentController]).to receive(:verify_access)
-            .with([:admin], controller_instance).and_return(true)
+            .with(user, controller_instance).and_return(true)
         end
 
         it "returns true" do
@@ -100,7 +96,7 @@ RSpec.describe Rabarber::Core::Access do
       context "if role doesn't have access to the controller's parent" do
         before do
           allow(permissions.controller_rules[DummyParentController]).to receive(:verify_access)
-            .with([:admin], controller_instance).and_return(false)
+            .with(user, controller_instance).and_return(false)
         end
 
         it "returns false" do
@@ -119,11 +115,12 @@ RSpec.describe Rabarber::Core::Access do
   end
 
   describe ".action_accessible?" do
-    subject { permissions.action_accessible?([:admin], controller, action, controller_instance) }
+    subject { permissions.action_accessible?(user, action, controller_instance) }
 
-    let(:controller_instance) { double }
+    let(:user) { User.create! }
+    let(:controller_instance) { controller.new }
 
-    before { permissions.add(DummyController, :index, [:admin], nil, nil) }
+    before { permissions.add(DummyController, :index, [:admin], nil, nil, nil) }
 
     context "if controller is in permissions" do
       let(:controller) { DummyController }
@@ -134,7 +131,7 @@ RSpec.describe Rabarber::Core::Access do
         context "if role has access to the action" do
           before do
             allow(permissions.action_rules[controller].first).to receive(:verify_access)
-              .with([:admin], controller_instance).and_return(true)
+              .with(user, controller_instance).and_return(true)
           end
 
           it "returns true" do
@@ -145,7 +142,7 @@ RSpec.describe Rabarber::Core::Access do
         context "if role doesn't have access to the action" do
           before do
             allow(permissions.action_rules[controller].first).to receive(:verify_access)
-              .with([:admin], controller_instance).and_return(false)
+              .with(user, controller_instance).and_return(false)
           end
 
           it "returns false" do

--- a/spec/rabarber/core/access_spec.rb
+++ b/spec/rabarber/core/access_spec.rb
@@ -6,16 +6,16 @@ RSpec.describe Rabarber::Core::Access do
   before { permissions.extend(described_class) }
 
   describe ".access_granted?" do
-    subject { permissions.access_granted?([:admin, :client], DummyController, :index, dynamic_rule_receiver) }
+    subject { permissions.access_granted?([:admin, :client], DummyController, :index, controller_instance) }
 
-    let(:dynamic_rule_receiver) { double }
+    let(:controller_instance) { double }
 
     context "if controller is accessible" do
       before do
         allow(permissions).to receive(:controller_accessible?)
-          .with([:admin, :client], DummyController, dynamic_rule_receiver).and_return(true)
+          .with([:admin, :client], DummyController, controller_instance).and_return(true)
         allow(permissions).to receive(:action_accessible?)
-          .with([:admin, :client], DummyController, :index, dynamic_rule_receiver).and_return(false)
+          .with([:admin, :client], DummyController, :index, controller_instance).and_return(false)
       end
 
       it "returns true" do
@@ -26,9 +26,9 @@ RSpec.describe Rabarber::Core::Access do
     context "if action is accessible" do
       before do
         allow(permissions).to receive(:controller_accessible?)
-          .with([:admin, :client], DummyController, dynamic_rule_receiver).and_return(false)
+          .with([:admin, :client], DummyController, controller_instance).and_return(false)
         allow(permissions).to receive(:action_accessible?)
-          .with([:admin, :client], DummyController, :index, dynamic_rule_receiver).and_return(true)
+          .with([:admin, :client], DummyController, :index, controller_instance).and_return(true)
       end
 
       it "returns true" do
@@ -39,9 +39,9 @@ RSpec.describe Rabarber::Core::Access do
     context "if controller and action are not accessible" do
       before do
         allow(permissions).to receive(:controller_accessible?)
-          .with([:admin, :client], DummyController, dynamic_rule_receiver).and_return(false)
+          .with([:admin, :client], DummyController, controller_instance).and_return(false)
         allow(permissions).to receive(:action_accessible?)
-          .with([:admin, :client], DummyController, :index, dynamic_rule_receiver).and_return(false)
+          .with([:admin, :client], DummyController, :index, controller_instance).and_return(false)
       end
 
       it "returns false" do
@@ -51,9 +51,9 @@ RSpec.describe Rabarber::Core::Access do
   end
 
   describe ".controller_accessible?" do
-    subject { permissions.controller_accessible?([:admin], controller, dynamic_rule_receiver) }
+    subject { permissions.controller_accessible?([:admin], controller, controller_instance) }
 
-    let(:dynamic_rule_receiver) { double }
+    let(:controller_instance) { double }
 
     before { permissions.add(DummyParentController, nil, [:admin], nil, nil) }
 
@@ -63,7 +63,7 @@ RSpec.describe Rabarber::Core::Access do
       context "if role has access to the controller" do
         before do
           allow(permissions.controller_rules[controller]).to receive(:verify_access)
-            .with([:admin], dynamic_rule_receiver).and_return(true)
+            .with([:admin], controller_instance).and_return(true)
         end
 
         it "returns true" do
@@ -74,7 +74,7 @@ RSpec.describe Rabarber::Core::Access do
       context "if role doesn't have access to the controller" do
         before do
           allow(permissions.controller_rules[controller]).to receive(:verify_access)
-            .with([:admin], dynamic_rule_receiver).and_return(false)
+            .with([:admin], controller_instance).and_return(false)
         end
 
         it "returns false" do
@@ -89,7 +89,7 @@ RSpec.describe Rabarber::Core::Access do
       context "if role has access to the controller's parent" do
         before do
           allow(permissions.controller_rules[DummyParentController]).to receive(:verify_access)
-            .with([:admin], dynamic_rule_receiver).and_return(true)
+            .with([:admin], controller_instance).and_return(true)
         end
 
         it "returns true" do
@@ -100,7 +100,7 @@ RSpec.describe Rabarber::Core::Access do
       context "if role doesn't have access to the controller's parent" do
         before do
           allow(permissions.controller_rules[DummyParentController]).to receive(:verify_access)
-            .with([:admin], dynamic_rule_receiver).and_return(false)
+            .with([:admin], controller_instance).and_return(false)
         end
 
         it "returns false" do
@@ -119,9 +119,9 @@ RSpec.describe Rabarber::Core::Access do
   end
 
   describe ".action_accessible?" do
-    subject { permissions.action_accessible?([:admin], controller, action, dynamic_rule_receiver) }
+    subject { permissions.action_accessible?([:admin], controller, action, controller_instance) }
 
-    let(:dynamic_rule_receiver) { double }
+    let(:controller_instance) { double }
 
     before { permissions.add(DummyController, :index, [:admin], nil, nil) }
 
@@ -134,7 +134,7 @@ RSpec.describe Rabarber::Core::Access do
         context "if role has access to the action" do
           before do
             allow(permissions.action_rules[controller].first).to receive(:verify_access)
-              .with([:admin], dynamic_rule_receiver).and_return(true)
+              .with([:admin], controller_instance).and_return(true)
           end
 
           it "returns true" do
@@ -145,7 +145,7 @@ RSpec.describe Rabarber::Core::Access do
         context "if role doesn't have access to the action" do
           before do
             allow(permissions.action_rules[controller].first).to receive(:verify_access)
-              .with([:admin], dynamic_rule_receiver).and_return(false)
+              .with([:admin], controller_instance).and_return(false)
           end
 
           it "returns false" do

--- a/spec/rabarber/core/permissions_integrity_checker_spec.rb
+++ b/spec/rabarber/core/permissions_integrity_checker_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Rabarber::Core::PermissionsIntegrityChecker do
     let(:controller) { nil }
 
     context "when action is missing" do
-      before { Rabarber::Core::Permissions.add(DummyAuthController, :index, [:admin], nil, nil) }
+      before { Rabarber::Core::Permissions.add(DummyAuthController, :index, [:admin], nil, nil, nil) }
 
       it "raises error" do
         expect { subject }.to raise_error(Rabarber::Error, "Following actions were passed to 'grant_access' method but are not defined in the controller: [{DummyAuthController=>[:index]}]")
@@ -28,8 +28,8 @@ RSpec.describe Rabarber::Core::PermissionsIntegrityChecker do
 
     context "when action is missing" do
       before do
-        Rabarber::Core::Permissions.add(DummyAuthController, :index, [:admin], nil, nil)
-        Rabarber::Core::Permissions.add(DummyAuthController, :show, [], nil, nil)
+        Rabarber::Core::Permissions.add(DummyAuthController, :index, [:admin], Project, nil, nil)
+        Rabarber::Core::Permissions.add(DummyAuthController, :show, [], Project.create!, nil, nil)
       end
 
       it "raises error" do

--- a/spec/rabarber/core/permissions_spec.rb
+++ b/spec/rabarber/core/permissions_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe Rabarber::Core::Permissions do
 
     context "when action is given" do
       before do
-        allow(Rabarber::Core::Rule).to receive(:new).with(:index, [:admin], nil, :dynamic_rule, false).and_return(rule)
+        allow(Rabarber::Core::Rule).to receive(:new).with(:index, [:admin], :context, :dynamic_rule, false).and_return(rule)
       end
 
       it "adds permissions to the action rules storage" do
-        expect { permissions.add(DummyController, :index, [:admin], nil, :dynamic_rule, false) }
+        expect { permissions.add(DummyController, :index, [:admin], :context, :dynamic_rule, false) }
           .to change { permissions.instance.storage[:action_rules] }
           .to({ DummyController => [rule] })
       end

--- a/spec/rabarber/core/permissions_spec.rb
+++ b/spec/rabarber/core/permissions_spec.rb
@@ -9,21 +9,21 @@ RSpec.describe Rabarber::Core::Permissions do
 
     context "when action is given" do
       before do
-        allow(Rabarber::Core::Rule).to receive(:new).with(:index, [:admin], :dynamic_rule, false).and_return(rule)
+        allow(Rabarber::Core::Rule).to receive(:new).with(:index, [:admin], nil, :dynamic_rule, false).and_return(rule)
       end
 
       it "adds permissions to the action rules storage" do
-        expect { permissions.add(DummyController, :index, [:admin], :dynamic_rule, false) }
+        expect { permissions.add(DummyController, :index, [:admin], nil, :dynamic_rule, false) }
           .to change { permissions.instance.storage[:action_rules] }
           .to({ DummyController => [rule] })
       end
     end
 
     context "when no action is given" do
-      before { allow(Rabarber::Core::Rule).to receive(:new).with(nil, [:admin, :manager], nil, nil).and_return(rule) }
+      before { allow(Rabarber::Core::Rule).to receive(:new).with(nil, [:admin, :manager], nil, nil, nil).and_return(rule) }
 
       it "adds permissions to the controller rules storage" do
-        expect { permissions.add(DummyController, nil, [:admin, :manager], nil, nil) }
+        expect { permissions.add(DummyController, nil, [:admin, :manager], nil, nil, nil) }
           .to change { permissions.instance.storage[:controller_rules] }
           .to({ DummyController => rule })
       end
@@ -33,8 +33,8 @@ RSpec.describe Rabarber::Core::Permissions do
   describe ".controller_rules" do
     context "if controller rules exist" do
       before do
-        permissions.add(DummyController, nil, [:admin], -> (foo) { foo }, :bar)
-        permissions.add(DummyParentController, nil, [], nil, nil)
+        permissions.add(DummyController, nil, [:admin], nil, -> (foo) { foo }, :bar)
+        permissions.add(DummyParentController, nil, [], nil, nil, nil)
       end
 
       it "returns rules for controllers" do
@@ -52,8 +52,8 @@ RSpec.describe Rabarber::Core::Permissions do
   describe ".action_rules" do
     context "if action rules exist" do
       before do
-        permissions.add(DummyController, :index, [], nil, nil)
-        permissions.add(DummyPagesController, :show, [:manager, :admin], -> { true }, :foo)
+        permissions.add(DummyController, :index, [], nil, nil, nil)
+        permissions.add(DummyPagesController, :show, [:manager, :admin], nil, -> { true }, :foo)
       end
 
       it "returns rules for actions" do

--- a/spec/rabarber/core/roleable_spec.rb
+++ b/spec/rabarber/core/roleable_spec.rb
@@ -15,13 +15,9 @@ RSpec.describe Rabarber::Core::Roleable do
     subject { DummyController.new.roleable_roles }
 
     context "when user exists" do
-      before do
-        user.assign_roles(:admin)
-        user.assign_roles(:manager, context: Project)
-        user.assign_roles(:client, context: Project.create!)
-      end
+      before { user.assign_roles(:admin, :manager) }
 
-      it { is_expected.to match_array(Rabarber::Role.all) }
+      it { is_expected.to contain_exactly(:admin, :manager) }
     end
 
     context "when user does not exist" do

--- a/spec/rabarber/core/roleable_spec.rb
+++ b/spec/rabarber/core/roleable_spec.rb
@@ -15,9 +15,13 @@ RSpec.describe Rabarber::Core::Roleable do
     subject { DummyController.new.roleable_roles }
 
     context "when user exists" do
-      before { user.assign_roles(:admin, :manager) }
+      before do
+        user.assign_roles(:admin)
+        user.assign_roles(:manager, context: Project)
+        user.assign_roles(:client, context: Project.create!)
+      end
 
-      it { is_expected.to contain_exactly(:admin, :manager) }
+      it { is_expected.to match_array(Rabarber::Role.all) }
     end
 
     context "when user does not exist" do

--- a/spec/rabarber/core/roleable_spec.rb
+++ b/spec/rabarber/core/roleable_spec.rb
@@ -12,12 +12,18 @@ RSpec.describe Rabarber::Core::Roleable do
   end
 
   describe "#roleable_roles" do
-    subject { DummyController.new.roleable_roles }
+    subject { DummyController.new.roleable_roles(context: Project) }
 
     context "when user exists" do
-      before { user.assign_roles(:admin, :manager) }
+      before { user.assign_roles(:admin, :manager, context: Project) }
 
       it { is_expected.to contain_exactly(:admin, :manager) }
+    end
+
+    context "when user exists and has no such roles" do
+      before { user.assign_roles(:admin, :manager, context: nil) }
+
+      it { is_expected.to be_empty }
     end
 
     context "when user does not exist" do

--- a/spec/rabarber/core/rule_spec.rb
+++ b/spec/rabarber/core/rule_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Rabarber::Core::Rule do
   describe "#verify_access" do
     subject { rule.verify_access(:admin, DummyController) }
 
-    let(:rule) { described_class.new(:index, :admin, nil, -> { true }, nil) }
+    let(:rule) { described_class.new(:index, :admin, -> { Project }, -> { true }, nil) }
 
     context "if all conditions are met" do
       before do
@@ -46,9 +46,9 @@ RSpec.describe Rabarber::Core::Rule do
     subject { rule.roles_permitted?(user, DummyController.new) }
 
     let(:user) { User.create! }
-    let(:rule) { described_class.new(:index, roles, nil, nil, nil) }
+    let(:rule) { described_class.new(:index, roles, { context_type: "Project", context_id: nil }, nil, nil) }
 
-    before { user.assign_roles(*user_roles) }
+    before { user.assign_roles(*user_roles, context: Project) }
 
     context "if roles are permitted" do
       let(:roles) { :admin }

--- a/spec/rabarber/core/rule_spec.rb
+++ b/spec/rabarber/core/rule_spec.rb
@@ -109,9 +109,9 @@ RSpec.describe Rabarber::Core::Rule do
   end
 
   describe "#dynamic_rule_followed?" do
-    subject { rule.dynamic_rule_followed?(dynamic_rule_receiver) }
+    subject { rule.dynamic_rule_followed?(controller_instance) }
 
-    let(:dynamic_rule_receiver) { double }
+    let(:controller_instance) { double }
     let(:rule) { described_class.new(:index, :manager, dynamic_rule, negated_dynamic_rule) }
 
     context "both dynamic rules are empty" do
@@ -124,7 +124,7 @@ RSpec.describe Rabarber::Core::Rule do
     end
 
     context "when dynamic rule is a proc" do
-      before { allow(dynamic_rule_receiver).to receive(:params).and_return({ foo: "bar" }) }
+      before { allow(controller_instance).to receive(:params).and_return({ foo: "bar" }) }
 
       context "when negated dynamic rule is nil" do
         let(:negated_dynamic_rule) { nil }
@@ -194,7 +194,7 @@ RSpec.describe Rabarber::Core::Rule do
     end
 
     context "when dynamic rule is a method name" do
-      before { allow(dynamic_rule_receiver).to receive_messages(foo: true, bar: false) }
+      before { allow(controller_instance).to receive_messages(foo: true, bar: false) }
 
       context "when negated dynamic rule is nil" do
         let(:negated_dynamic_rule) { nil }

--- a/spec/rabarber/helpers/helpers_spec.rb
+++ b/spec/rabarber/helpers/helpers_spec.rb
@@ -6,10 +6,11 @@ RSpec.describe Rabarber::Helpers do
   before { allow(dummy_helper).to receive(:current_user).and_return(user) }
 
   describe "#visible_to" do
-    subject { dummy_helper.visible_to(*roles) { "foo" } }
+    subject { dummy_helper.visible_to(*roles, context: context) { "foo" } }
 
     let(:user) { User.create! }
     let(:roles) { [:manager, :accountant] }
+    let(:context) { Project }
 
     context "when there is no current user" do
       let(:user) { nil }
@@ -26,23 +27,30 @@ RSpec.describe Rabarber::Helpers do
     end
 
     context "when the user has one of the given roles" do
-      before { user.assign_roles(:admin, :client, :accountant) }
+      before { user.assign_roles(:admin, :client, :accountant, context: Project) }
 
       it { is_expected.to eq("foo") }
     end
 
     context "when the user does not have any of the given roles" do
-      before { user.assign_roles(:admin, :client) }
+      before { user.assign_roles(:admin, :client, context: Project) }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the user has roles with the same name in different context" do
+      before { user.assign_roles(:manager, :accountant, context: Project.create!) }
 
       it { is_expected.to be_nil }
     end
   end
 
   describe "#hidden_from" do
-    subject { dummy_helper.hidden_from(*roles) { "foo" } }
+    subject { dummy_helper.hidden_from(*roles, context: context) { "foo" } }
 
     let(:user) { User.create! }
     let(:roles) { [:manager, :accountant] }
+    let(:context) { nil }
 
     context "when there is no current user" do
       let(:user) { nil }
@@ -66,6 +74,12 @@ RSpec.describe Rabarber::Helpers do
 
     context "when the user does not have any of the given roles" do
       before { user.assign_roles(:admin, :client) }
+
+      it { is_expected.to eq("foo") }
+    end
+
+    context "when the user has roles with the same name in different context" do
+      before { user.assign_roles(:manager, :accountant, context: Project.create!) }
 
       it { is_expected.to eq("foo") }
     end

--- a/spec/rabarber/input/action_spec.rb
+++ b/spec/rabarber/input/action_spec.rb
@@ -26,12 +26,14 @@ RSpec.describe Rabarber::Input::Action do
 
     context "when the given action is invalid" do
       [1, ["index"], "", Symbol, {}, :""].each do |invalid_action|
-        let(:action) { invalid_action }
+        context "when '#{invalid_action}' is given" do
+          let(:action) { invalid_action }
 
-        it "raises an error when '#{invalid_action}' is given as an action name" do
-          expect { subject }.to raise_error(
-            Rabarber::InvalidArgumentError, "Action name must be a Symbol or a String"
-          )
+          it "raises an error" do
+            expect { subject }.to raise_error(
+              Rabarber::InvalidArgumentError, "Action name must be a Symbol or a String"
+            )
+          end
         end
       end
     end

--- a/spec/rabarber/input/authorization_context_spec.rb
+++ b/spec/rabarber/input/authorization_context_spec.rb
@@ -17,6 +17,17 @@ RSpec.describe Rabarber::Input::AuthorizationContext do
         it { is_expected.to eq(context_type: "Project", context_id: context.id) }
       end
 
+      context "when an instance of ActiveRecord::Base is given but not persisted" do
+        let(:context) { Project.new }
+
+        it "raises an error" do
+          expect { subject }.to raise_error(
+            Rabarber::InvalidArgumentError,
+            "Context must be a Class, an instance of ActiveRecord model, a Symbol, a String, or a Proc"
+          )
+        end
+      end
+
       context "when nil is given" do
         let(:context) { nil }
 
@@ -50,7 +61,7 @@ RSpec.describe Rabarber::Input::AuthorizationContext do
           it "raises an error" do
             expect { subject }.to raise_error(
               Rabarber::InvalidArgumentError,
-              "Context must be a Class, an instance of ActiveRecord::Base, a Symbol, a String, or a Proc"
+              "Context must be a Class, an instance of ActiveRecord model, a Symbol, a String, or a Proc"
             )
           end
         end

--- a/spec/rabarber/input/authorization_context_spec.rb
+++ b/spec/rabarber/input/authorization_context_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+RSpec.describe Rabarber::Input::AuthorizationContext do
+  describe "#process" do
+    subject { described_class.new(context).process }
+
+    context "when the given context is valid" do
+      context "when a class is given" do
+        let(:context) { Project }
+
+        it { is_expected.to eq(context_type: "Project", context_id: nil) }
+      end
+
+      context "when an instance of ActiveRecord::Base is given" do
+        let(:context) { Project.create! }
+
+        it { is_expected.to eq(context_type: "Project", context_id: context.id) }
+      end
+
+      context "when nil is given" do
+        let(:context) { nil }
+
+        it { is_expected.to eq(context_type: nil, context_id: nil) }
+      end
+
+      context "when a string is given" do
+        let(:context) { "project" }
+
+        it { is_expected.to eq(:project) }
+      end
+
+      context "when a symbol is given" do
+        let(:context) { :project }
+
+        it { is_expected.to eq(:project) }
+      end
+
+      context "when a proc is given" do
+        let(:context) { -> { Project } }
+
+        it { is_expected.to eq(context) }
+      end
+    end
+
+    # context "when the given context is invalid" do
+    #   [1, ["context"], "context", "", :context, {}, :""].each do |invalid_context|
+    #     let(:context) { invalid_context }
+
+    #     it "raises an error when '#{invalid_context}' is given as an action name" do
+    #       expect { subject }.to raise_error(
+    #         Rabarber::InvalidArgumentError, "Context must be a Class or an instance of ActiveRecord::Base"
+    #       )
+    #     end
+    #   end
+    # end
+  end
+end

--- a/spec/rabarber/input/authorization_context_spec.rb
+++ b/spec/rabarber/input/authorization_context_spec.rb
@@ -42,16 +42,19 @@ RSpec.describe Rabarber::Input::AuthorizationContext do
       end
     end
 
-    # context "when the given context is invalid" do
-    #   [1, ["context"], "context", "", :context, {}, :""].each do |invalid_context|
-    #     let(:context) { invalid_context }
+    context "when the given context is invalid" do
+      [1, ["context"], "", {}, :""].each do |invalid_context|
+        context "when '#{invalid_context}' is given" do
+          let(:context) { invalid_context }
 
-    #     it "raises an error when '#{invalid_context}' is given as an action name" do
-    #       expect { subject }.to raise_error(
-    #         Rabarber::InvalidArgumentError, "Context must be a Class or an instance of ActiveRecord::Base"
-    #       )
-    #     end
-    #   end
-    # end
+          it "raises an error" do
+            expect { subject }.to raise_error(
+              Rabarber::InvalidArgumentError,
+              "Context must be a Class, an instance of ActiveRecord::Base, a Symbol, a String, or a Proc"
+            )
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/rabarber/input/context_spec.rb
+++ b/spec/rabarber/input/context_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe Rabarber::Input::Context do
       context "when a class is given" do
         let(:context) { Project }
 
-        it { is_expected.to eq(context_type: Project, context_id: nil) }
+        it { is_expected.to eq(context_type: "Project", context_id: nil) }
       end
 
       context "when an instance of ActiveRecord::Base is given" do
         let(:context) { Project.create! }
 
-        it { is_expected.to eq(context_type: Project, context_id: context.id) }
+        it { is_expected.to eq(context_type: "Project", context_id: context.id) }
       end
 
       context "when nil is given" do

--- a/spec/rabarber/input/context_spec.rb
+++ b/spec/rabarber/input/context_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe Rabarber::Input::Context do
 
         it { is_expected.to eq(context_type: nil, context_id: nil) }
       end
+
+      context "when the context is already processed" do
+        let(:context) { { context_type: "Project", context_id: 1 } }
+
+        it { is_expected.to eq(context_type: "Project", context_id: 1) }
+      end
     end
 
     context "when the given context is invalid" do

--- a/spec/rabarber/input/context_spec.rb
+++ b/spec/rabarber/input/context_spec.rb
@@ -17,6 +17,17 @@ RSpec.describe Rabarber::Input::Context do
         it { is_expected.to eq(context_type: "Project", context_id: context.id) }
       end
 
+      context "when an instance of ActiveRecord::Base is given but not persisted" do
+        let(:context) { Project.new }
+
+        it "raises an error" do
+          expect { subject }.to raise_error(
+            Rabarber::InvalidArgumentError,
+            "Context must be a Class or an instance of ActiveRecord model"
+          )
+        end
+      end
+
       context "when nil is given" do
         let(:context) { nil }
 
@@ -38,7 +49,7 @@ RSpec.describe Rabarber::Input::Context do
           it "raises an error" do
             expect { subject }.to raise_error(
               Rabarber::InvalidArgumentError,
-              "Context must be a Class or an instance of ActiveRecord::Base"
+              "Context must be a Class or an instance of ActiveRecord model"
             )
           end
         end

--- a/spec/rabarber/input/context_spec.rb
+++ b/spec/rabarber/input/context_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe Rabarber::Input::Context do
+  describe "#process" do
+    subject { described_class.new(context).process }
+
+    context "when the given context is valid" do
+      context "when a class is given" do
+        let(:context) { Project }
+
+        it { is_expected.to eq(context_type: Project, context_id: nil) }
+      end
+
+      context "when an instance of ActiveRecord::Base is given" do
+        let(:context) { Project.create! }
+
+        it { is_expected.to eq(context_type: Project, context_id: context.id) }
+      end
+
+      context "when nil is given" do
+        let(:context) { nil }
+
+        it { is_expected.to eq(context_type: nil, context_id: nil) }
+      end
+    end
+
+    context "when the given context is invalid" do
+      [1, ["context"], "context", "", :context, {}, :""].each do |invalid_context|
+        let(:context) { invalid_context }
+
+        it "raises an error when '#{invalid_context}' is given as an action name" do
+          expect { subject }.to raise_error(
+            Rabarber::InvalidArgumentError, "Context must be a Class or an instance of ActiveRecord::Base"
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/rabarber/input/context_spec.rb
+++ b/spec/rabarber/input/context_spec.rb
@@ -32,12 +32,15 @@ RSpec.describe Rabarber::Input::Context do
 
     context "when the given context is invalid" do
       [1, ["context"], "context", "", :context, {}, :""].each do |invalid_context|
-        let(:context) { invalid_context }
+        context "when '#{invalid_context}' is given" do
+          let(:context) { invalid_context }
 
-        it "raises an error when '#{invalid_context}' is given as an action name" do
-          expect { subject }.to raise_error(
-            Rabarber::InvalidArgumentError, "Context must be a Class or an instance of ActiveRecord::Base"
-          )
+          it "raises an error" do
+            expect { subject }.to raise_error(
+              Rabarber::InvalidArgumentError,
+              "Context must be a Class or an instance of ActiveRecord::Base"
+            )
+          end
         end
       end
     end

--- a/spec/rabarber/input/dynamic_rule_spec.rb
+++ b/spec/rabarber/input/dynamic_rule_spec.rb
@@ -32,13 +32,15 @@ RSpec.describe Rabarber::Input::DynamicRule do
 
     context "when the given dynamic rule is invalid" do
       [1, ["rule"], "", :"", Symbol, [], {}].each do |invalid_dynamic_rule|
-        let(:dynamic_rule) { invalid_dynamic_rule }
+        context "when '#{invalid_dynamic_rule}' is given" do
+          let(:dynamic_rule) { invalid_dynamic_rule }
 
-        it "raises an error when '#{invalid_dynamic_rule}' is given as a dynamic rule" do
-          expect { subject }.to raise_error(
-            Rabarber::InvalidArgumentError,
-            "Dynamic rule must be a Symbol, a String, or a Proc"
-          )
+          it "raises an error" do
+            expect { subject }.to raise_error(
+              Rabarber::InvalidArgumentError,
+              "Dynamic rule must be a Symbol, a String, or a Proc"
+            )
+          end
         end
       end
     end

--- a/spec/rabarber/input/role_spec.rb
+++ b/spec/rabarber/input/role_spec.rb
@@ -20,13 +20,15 @@ RSpec.describe Rabarber::Input::Role do
 
     context "when the given role is invalid" do
       [nil, "", 1, [""], Symbol, :"a-user", :Admin, "Admin", "admin ", { manager: true }].each do |invalid_role|
-        let(:role) { invalid_role }
+        context "when '#{invalid_role}' is given" do
+          let(:role) { invalid_role }
 
-        it "raises an error when '#{invalid_role}' is given as a role name" do
-          expect { subject }.to raise_error(
-            Rabarber::InvalidArgumentError,
-            "Role name must be a Symbol or a String and may only contain lowercase letters, numbers and underscores"
-          )
+          it "raises an error" do
+            expect { subject }.to raise_error(
+              Rabarber::InvalidArgumentError,
+              "Role name must be a Symbol or a String and may only contain lowercase letters, numbers and underscores"
+            )
+          end
         end
       end
     end

--- a/spec/rabarber/input/roles_spec.rb
+++ b/spec/rabarber/input/roles_spec.rb
@@ -26,13 +26,15 @@ RSpec.describe Rabarber::Input::Roles do
 
     context "when the given role is invalid" do
       [1, [""], Symbol, :"a-user", :Admin, "Admin", "admin ", { manager: true }].each do |invalid_role|
-        let(:roles) { invalid_role }
+        context "when '#{invalid_role}' is given" do
+          let(:roles) { invalid_role }
 
-        it "raises an error when '#{invalid_role}' is given as a role name" do
-          expect { subject }.to raise_error(
-            Rabarber::InvalidArgumentError,
-            "Role names must be Symbols or Strings and may only contain lowercase letters, numbers and underscores"
-          )
+          it "raises an error" do
+            expect { subject }.to raise_error(
+              Rabarber::InvalidArgumentError,
+              "Role names must be Symbols or Strings and may only contain lowercase letters, numbers and underscores"
+            )
+          end
         end
       end
     end

--- a/spec/rabarber/input/types/boolean_spec.rb
+++ b/spec/rabarber/input/types/boolean_spec.rb
@@ -20,10 +20,12 @@ RSpec.describe Rabarber::Input::Types::Boolean do
 
     context "when the given value is invalid" do
       [nil, 1, "foo", :foo, [], {}, User].each do |invalid_value|
-        let(:value) { invalid_value }
+        context "when '#{invalid_value}' is given" do
+          let(:value) { invalid_value }
 
-        it "raises an ArgumentError when '#{invalid_value}' is given" do
-          expect { subject }.to raise_error(Rabarber::Error, "Error")
+          it "raises an error" do
+            expect { subject }.to raise_error(Rabarber::Error, "Error")
+          end
         end
       end
     end

--- a/spec/rabarber/input/types/proc_spec.rb
+++ b/spec/rabarber/input/types/proc_spec.rb
@@ -14,10 +14,12 @@ RSpec.describe Rabarber::Input::Types::Proc do
 
     context "when the given value is invalid" do
       [nil, 1, "foo", :foo, [], {}, User].each do |invalid_value|
-        let(:value) { invalid_value }
+        context "when '#{invalid_value}' is given" do
+          let(:value) { invalid_value }
 
-        it "raises an ArgumentError when '#{invalid_value}' is given" do
-          expect { subject }.to raise_error(Rabarber::Error, "Error")
+          it "raises an error" do
+            expect { subject }.to raise_error(Rabarber::Error, "Error")
+          end
         end
       end
     end

--- a/spec/rabarber/input/types/symbol_spec.rb
+++ b/spec/rabarber/input/types/symbol_spec.rb
@@ -20,10 +20,12 @@ RSpec.describe Rabarber::Input::Types::Symbol do
 
     context "when the given value is invalid" do
       [nil, 1, [], {}, User, "", :""].each do |invalid_value|
-        let(:value) { invalid_value }
+        context "when '#{invalid_value}' is given" do
+          let(:value) { invalid_value }
 
-        it "raises an ArgumentError when '#{invalid_value}' is given" do
-          expect { subject }.to raise_error(Rabarber::Error, "Error")
+          it "raises an error" do
+            expect { subject }.to raise_error(Rabarber::Error, "Error")
+          end
         end
       end
     end

--- a/spec/rabarber/models/role_spec.rb
+++ b/spec/rabarber/models/role_spec.rb
@@ -36,7 +36,9 @@ RSpec.describe Rabarber::Role do
   end
 
   describe ".names" do
-    subject { described_class.names }
+    subject { described_class.names(context: context) }
+
+    let(:context) { nil }
 
     context "when there are no roles" do
       it { is_expected.to eq([]) }
@@ -53,6 +55,44 @@ RSpec.describe Rabarber::Role do
 
       it "returns an array of role names" do
         expect(subject).to match_array(role_names)
+      end
+    end
+
+    context "when there are some roles but in a different context" do
+      let(:role_names) { [:admin, :manager] }
+
+      before do
+        role_names.each do |role_name|
+          described_class.create!(name: role_name, context_type: "Project")
+        end
+      end
+
+      it { is_expected.to eq([]) }
+    end
+
+    context "when context is given" do
+      let(:role_names) { [:admin, :manager] }
+      let(:project) { Project.create! }
+      let(:context) { project }
+
+      before do
+        role_names.each do |role_name|
+          described_class.create!(name: role_name, context_type: "Project", context_id: project.id)
+        end
+
+        described_class.create!(name: :accountant)
+        described_class.create!(name: :manager, context_type: "Project")
+      end
+
+      it "returns an array of role names in the given context" do
+        expect(subject).to match_array(role_names)
+      end
+
+      it "uses Input::Context to process the given context" do
+        input_processor = instance_double(Rabarber::Input::Context)
+        allow(Rabarber::Input::Context).to receive(:new).with(project).and_return(input_processor)
+        expect(input_processor).to receive(:process).with(no_args)
+        subject
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,6 +43,6 @@ end
 load "#{File.dirname(__FILE__)}/support/schema.rb"
 
 require "#{File.dirname(__FILE__)}/support/application"
+require "#{File.dirname(__FILE__)}/support/models"
 require "#{File.dirname(__FILE__)}/support/controllers"
 require "#{File.dirname(__FILE__)}/support/helpers"
-require "#{File.dirname(__FILE__)}/support/models"

--- a/spec/support/application.rb
+++ b/spec/support/application.rb
@@ -37,4 +37,10 @@ DummyApplication.routes.draw do
   get "skip_no_rules", to: "skip_authorization#skip_no_rules"
   put "skip_rules", to: "skip_authorization#skip_rules"
   post "no_skip", to: "skip_authorization#no_skip"
+
+  get "global_ctx", to: "context#global_ctx"
+  post "class_ctx", to: "context#class_ctx"
+  put "instance_ctx", to: "context#instance_ctx"
+  patch "symbol_ctx", to: "context#symbol_ctx"
+  delete "proc_ctx", to: "context#proc_ctx"
 end

--- a/spec/support/controllers.rb
+++ b/spec/support/controllers.rb
@@ -99,3 +99,24 @@ class SkipAuthorizationController < ApplicationController
   grant_access action: :no_skip, roles: :developer
   def no_skip = head(:ok)
 end
+
+class ContextController < ApplicationController
+  grant_access action: :global_ctx, roles: :admin, context: nil
+  def global_ctx = head(:ok)
+
+  grant_access action: :class_ctx, roles: :admin, context: Project
+  def class_ctx = head(:ok)
+
+  grant_access action: :instance_ctx, roles: :admin, context: Project.create!
+  def instance_ctx = head(:ok)
+
+  grant_access action: :symbol_ctx, roles: :admin, context: :project
+  def symbol_ctx = head(:ok)
+
+  grant_access action: :proc_ctx, roles: :admin, context: -> { Project }
+  def proc_ctx = head(:ok)
+
+  private
+
+  def project = Project.create!
+end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -9,3 +9,5 @@ class User < ApplicationRecord
 end
 
 class Client < ApplicationRecord; end
+
+class Project < ApplicationRecord; end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -26,6 +26,11 @@ ActiveRecord::Schema.define do
     t.datetime "updated_at", null: false
   end
 
+  create_table "projects", force: true do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   add_foreign_key "rabarber_roles_roleables", "rabarber_roles", column: "role_id"
   add_foreign_key "rabarber_roles_roleables", "users", column: "roleable_id"
 end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -5,9 +5,12 @@ ActiveRecord::Schema.define do
 
   create_table "rabarber_roles", force: :cascade do |t|
     t.string "name", null: false
+    t.string "context_type"
+    t.integer "context_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["name"], name: "index_rabarber_roles_on_name", unique: true
+    t.index ["context_type", "context_id"], name: "index_rabarber_roles_on_context"
+    t.index ["name", "context_type", "context_id"], name: "index_rabarber_roles_on_name_and_context_type_and_context_id", unique: true
   end
 
   create_table "rabarber_roles_roleables", id: false, force: :cascade do |t|


### PR DESCRIPTION
The idea is to allow roles to be defined within some context (can be used for multi-tenancy and other cases where roles are not global), e.g.:

```rb
user.assign_roles(:admin, context: project)
user.assign_roles(:admin, context: Project)
user.assign_roles(:admin) # context is nil by default
```

The context can be an instance of an `ActiveRecord` model, a class, or `nil` (meaning the global context).

And this is how context could be used within the authorization rules:

```rb
grant_access roles: :admin, context: :project
grant_access roles: :admin, context: -> { Project.find(params[:id]) }
grant_access roles: :admin, context: Project
grant_access roles: :admin # context is nil by default
```